### PR TITLE
Fix aml-autoscript 

### DIFF
--- a/recipes-bsp/aml-autoscript/files/aml_autoscript.cmd
+++ b/recipes-bsp/aml-autoscript/files/aml_autoscript.cmd
@@ -1,6 +1,6 @@
 setenv kernel_loadaddr "0x11000000"
 setenv initrd_loadaddr "0x13000000"
 setenv dtb_mem_addr "0x1000000"
-setenv bootargs "console=ttyAML0,115200n8 console=tty0 no_console_suspend consoleblank=0 root=/dev/mmcblk1p2"
+setenv bootargs "console=ttyAML0,115200n8 console=tty0 no_console_suspend consoleblank=0 root=/dev/mmcblk1p2 rootwait"
 if fatload mmc 0 ${kernel_loadaddr} uImage; then if fatload mmc 0 ${dtb_mem_addr} ##DTB## ; then bootm ${kernel_loadaddr} - ${dtb_mem_addr} ; fi ; fi
 if fatload mmc 1 ${kernel_loadaddr} uImage; then if fatload mmc 1 ${dtb_mem_addr} ##DTB## ; then bootm ${kernel_loadaddr} - ${dtb_mem_addr} ; fi ; fi

--- a/recipes-bsp/aml-autoscript/files/aml_autoscript.cmd
+++ b/recipes-bsp/aml-autoscript/files/aml_autoscript.cmd
@@ -2,5 +2,5 @@ setenv kernel_loadaddr "0x11000000"
 setenv initrd_loadaddr "0x13000000"
 setenv dtb_mem_addr "0x1000000"
 setenv bootargs "console=ttyAML0,115200n8 console=tty0 no_console_suspend consoleblank=0 root=/dev/mmcblk1p2"
-if fatload mmc 0 ${kernel_loadaddr} uImage; then if fatload mmc 0 ${dtb_mem_addr} ##DTB## ; then booti ${kernel_loadaddr} - ${dtb_mem_addr} ; fi ; fi
-if fatload mmc 1 ${kernel_loadaddr} uImage; then if fatload mmc 1 ${dtb_mem_addr} ##DTB## ; then booti ${kernel_loadaddr} - ${dtb_mem_addr} ; fi ; fi
+if fatload mmc 0 ${kernel_loadaddr} uImage; then if fatload mmc 0 ${dtb_mem_addr} ##DTB## ; then bootm ${kernel_loadaddr} - ${dtb_mem_addr} ; fi ; fi
+if fatload mmc 1 ${kernel_loadaddr} uImage; then if fatload mmc 1 ${dtb_mem_addr} ##DTB## ; then bootm ${kernel_loadaddr} - ${dtb_mem_addr} ; fi ; fi


### PR DESCRIPTION
With these minor fixes, I was able to test that the load/run of aml_autoscript from MMC worked fine on the nexbox-a95x-s905x when starting from the vendor u-boot in eMMC.

With Amlogic vendor u-boot, from u-boot prompt, use `run recovery_from_sdcard` which loads/runs the aml_autoscript from MMC.

