### PR TITLE
use mmcblk0 on kvim and p212

### DIFF
--- a/conf/machine/amlogic-p212.conf
+++ b/conf/machine/amlogic-p212.conf
@@ -15,7 +15,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2018.01%"
 
 UBOOT_MACHINE = "p212_defconfig"
 UBOOT_EXTLINUX = "1"
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk2p1"
+UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
 UBOOT_EXTLINUX_FDT = "../meson-gxl-s905x-p212.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 

--- a/conf/machine/khadas-vim.conf
+++ b/conf/machine/khadas-vim.conf
@@ -14,7 +14,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2018.01%"
 
 UBOOT_MACHINE = "khadas-vim_defconfig"
 UBOOT_EXTLINUX = "1"
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk2p1"
+UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
 UBOOT_EXTLINUX_FDT = "../meson-gxl-s905x-khadas-vim.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 


### PR DESCRIPTION
While testing amlogic-image-headless-sd on khadas-vim and
amlogic-p212, both kernels seem to detect the SD card slot as mmcblk0.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>