### PR TITLE
nexbox-a1: build vendor u-boot

### DIFF
--- a/conf/machine/nexbox-a1.conf
+++ b/conf/machine/nexbox-a1.conf
@@ -3,5 +3,12 @@
 require conf/machine/include/amlogic-s912.inc
 require conf/machine/include/nexbox-a1-dtb.inc
 
-EXTRA_IMAGEDEPENDS += "aml-autoscript"
+EXTRA_IMAGEDEPENDS += "u-boot aml-autoscript"
+
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-amlogic"
+PREFERRED_PROVIDER_u-boot = "u-boot-amlogic"
+PREFERRED_VERSION_u-boot-amlogic = "v2015.01%"
+
+UBOOT_MACHINE = "gxm_q200_v1_config"
+
 IMAGE_BOOT_FILES += " aml_autoscript"


### PR DESCRIPTION
Build vendor uboot (using amlogic q200 reference.)

Tested on Nexbox A1, booting directly from SD card (eMMC erased.)
Also verified working u-boot networking (dhcp, tftp, etc)

Signed-off-by: Kevin Hilman <khilman@baylibre.com>