### PR TITLE
amlogic-p200: WIC: add vendor u-boot

### DIFF
--- a/conf/machine/amlogic-p200.conf
+++ b/conf/machine/amlogic-p200.conf
@@ -12,3 +12,8 @@ PREFERRED_VERSION_u-boot-amlogic = "v2015.01%"
 UBOOT_MACHINE = "gxb_p200_v1_config"
 
 IMAGE_BOOT_FILES += " aml_autoscript"
+
+# Generate an SDCard Image
+IMAGE_CLASSES += "image_types_meson"
+
+WKS_FILE = "sdimage-meson.wks"


### PR DESCRIPTION
Add vendor u-boot to the WIC image.

This doesn't do anything when the board already has vendor uboot in
eMMC, but if eMMC is erased, this allows p200 to boot.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>