### PR TITLE
libretech-cc-dtb.inc: remove non-existent dtb

### DIFF
--- a/conf/machine/include/libretech-cc-dtb.inc
+++ b/conf/machine/include/libretech-cc-dtb.inc
@@ -1,4 +1,4 @@
 # LibreTech CC
 
 KERNEL_DEVICETREE += "amlogic/meson-gxl-s905x-libretech-cc.dtb"
-IMAGE_BOOT_FILES += "Image-meson-gxl-s905x-libretech-cc.dtb;meson-gxl-s905x-libretech-cc.dtb"
+IMAGE_BOOT_FILES += "meson-gxl-s905x-libretech-cc.dtb"


### PR DESCRIPTION
Master currently doesn't build an "Image-meson-gxl-s905x-libretech-cc.dtb"
artifact.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>