### PR TITLE
amlogic-s400 configure the default alsa streams rate and format

### DIFF
--- a/recipes-bsp/alsa-board-conf/files/amlogic-s400/board.conf
+++ b/recipes-bsp/alsa-board-conf/files/amlogic-s400/board.conf
@@ -1,17 +1,23 @@
-pcm.s400 {
-    type asym
-    playback.pcm "plughw:0,0"
-    capture.pcm "plughw:0,3"
+pcm.linein {
+        type plug
+        slave {
+                pcm "plughw:0,3"
+                rate 48000
+                format S32_LE
+        }
 }
-
-pcm.line {
-    type plug
-    slave {
-        pcm s400
-        rate 48000
-        format S24_LE
-        channels 2
-    }
+pcm.lineout {
+        type plug
+        slave {
+                pcm "plughw:0,0"
+                rate 48000
+                format S24_LE
+                channels 2
+        }
 }
-
-pcm.!default pcm.line
+pcm.i2s {
+        type asym
+        playback.pcm lineout
+        capture.pcm linein
+}
+pcm.!default pcm.i2s


### PR DESCRIPTION
The amlogic-s400 audio path does not support every audio rate & format.
Use alsa plugins to specify the rate and format of the audio streams.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>