### PR TITLE
linux-yocto-meson32 5.2: Fix kernel build error

### DIFF
--- a/recipes-kernel/linux/linux-yocto-meson32-5.2/0001-UPSTREAM-drm-rcar-du-Fix-build-error.patch
+++ b/recipes-kernel/linux/linux-yocto-meson32-5.2/0001-UPSTREAM-drm-rcar-du-Fix-build-error.patch
@@ -1,0 +1,40 @@
+From 70f3336c6104b4b161bf311ff6e6648a2274f4f2 Mon Sep 17 00:00:00 2001
+From: Daniel Gomez <dagmcr@gmail.com>
+Date: Mon, 18 May 2020 22:16:46 +0200
+Subject: [PATCH] drm: rcar-du: Fix build error
+
+Select DRM_KMS_HELPER dependency.
+
+Build error when DRM_KMS_HELPER is not selected:
+
+drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0xd48): undefined reference to `drm_atomic_helper_bridge_duplicate_state'
+drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0xd50): undefined reference to `drm_atomic_helper_bridge_destroy_state'
+drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0xd70): undefined reference to `drm_atomic_helper_bridge_reset'
+drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0xdc8): undefined reference to `drm_atomic_helper_connector_reset'
+drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0xde0): undefined reference to `drm_helper_probe_single_connector_modes'
+drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0xe08): undefined reference to `drm_atomic_helper_connector_duplicate_state'
+drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0xe10): undefined reference to `drm_atomic_helper_connector_destroy_state'
+
+Signed-off-by: Daniel Gomez <dagmcr@gmail.com>
+Reviewed-by: Emil Velikov <emil.l.velikov@gmail.com>
+Reviewed-by: Kieran Bingham <kieran.bingham+renesas@ideasonboard.com>
+Reviewed-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+---
+ drivers/gpu/drm/rcar-du/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/rcar-du/Kconfig b/drivers/gpu/drm/rcar-du/Kconfig
+index 1529849e217e..7cdba77b1420 100644
+--- a/drivers/gpu/drm/rcar-du/Kconfig
++++ b/drivers/gpu/drm/rcar-du/Kconfig
+@@ -23,6 +23,7 @@ config DRM_RCAR_DW_HDMI
+ config DRM_RCAR_LVDS
+ 	tristate "R-Car DU LVDS Encoder Support"
+ 	depends on DRM && DRM_BRIDGE && OF
++	select DRM_KMS_HELPER
+ 	select DRM_PANEL
+ 	select OF_FLATTREE
+ 	select OF_OVERLAY
+-- 
+2.26.2
+

--- a/recipes-kernel/linux/linux-yocto-meson32_5.2.bb
+++ b/recipes-kernel/linux/linux-yocto-meson32_5.2.bb
@@ -2,10 +2,16 @@
 # Linux Support for 32bit Amlogic Meson SoCs
 #
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
+
 KERNEL_CLASSES = "kernel-uimage-meson"
 
 # Linux stable tree
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=git;nocheckout=1;branch=linux-5.2.y;name=meson"
+SRC_URI = " \
+	git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git;protocol=git;nocheckout=1;branch=linux-5.2.y;name=meson \
+	file://0001-UPSTREAM-drm-rcar-du-Fix-build-error.patch \
+"
+
 
 # tag: v4.20.3
 SRCREV_meson = "c3915fe1bf1235dbf3b0bced734c960202915bd5"


### PR DESCRIPTION
Add linux upstream patch to fix kernel build error dependency.

When compiling linux kernel using arch/arm/configs/multi_v7_defconfig it
generates the next error because of missing dependency:

| arm-poky-linux-gnueabi-ld.bfd: drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0x4): undefined reference to `drm_atomic_helper_connector_reset'
| arm-poky-linux-gnueabi-ld.bfd: drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0x10): undefined reference to `drm_helper_probe_single_connector_modes'
| arm-poky-linux-gnueabi-ld.bfd: drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0x24): undefined reference to `drm_atomic_helper_connector_duplicate_state'
| arm-poky-linux-gnueabi-ld.bfd: drivers/gpu/drm/rcar-du/rcar_lvds.o:(.rodata+0x28): undefined reference to `drm_atomic_helper_connector_destroy_state'
| /workdir/build/tmp/work-shared/amlogic-s805/kernel-source/Makefile:1054: recipe for target 'vmlinux' failed
| make[1]: *** [vmlinux] Error 1
| /workdir/build/tmp/work-shared/amlogic-s805/kernel-source/Makefile:179: recipe for target 'sub-make' failed
| make: *** [sub-make] Error 2
| WARNING: exit code 1 from a shell command.
|
ERROR: Task (/workdir/poky/../meta-meson/recipes-kernel/linux/linux-yocto-meson32_5.2.bb:do_compile) failed with exit code '1'

Signed-off-by: Daniel Gomez <dagmcr@gmail.com>