### PR TITLE
linux-meson64: fix perf build libbfd error

### DIFF
--- a/recipes-kernel/linux/linux-meson64-5.2/0233-UPSTREAM-perf-Make-perf-able-to-build-with-latest-libbfd.patch
+++ b/recipes-kernel/linux/linux-meson64-5.2/0233-UPSTREAM-perf-Make-perf-able-to-build-with-latest-libbfd.patch
@@ -1,0 +1,60 @@
+From 0ada120c883d4f1f6aafd01cf0fbb10d8bbba015 Mon Sep 17 00:00:00 2001
+From: Changbin Du <changbin.du@gmail.com>
+Date: Tue, 28 Jan 2020 23:29:38 +0800
+Subject: [PATCH] perf: Make perf able to build with latest libbfd
+
+libbfd has changed the bfd_section_* macros to inline functions
+bfd_section_<field> since 2019-09-18. See below two commits:
+  o http://www.sourceware.org/ml/gdb-cvs/2019-09/msg00064.html
+  o https://www.sourceware.org/ml/gdb-cvs/2019-09/msg00072.html
+
+This fix make perf able to build with both old and new libbfd.
+
+Signed-off-by: Changbin Du <changbin.du@gmail.com>
+Acked-by: Jiri Olsa <jolsa@redhat.com>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Link: http://lore.kernel.org/lkml/20200128152938.31413-1-changbin.du@gmail.com
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/srcline.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/srcline.c b/tools/perf/util/srcline.c
+index 6ccf6f6d09df..5b7d6c16d33f 100644
+--- a/tools/perf/util/srcline.c
++++ b/tools/perf/util/srcline.c
+@@ -193,16 +193,30 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
+ 	bfd_vma pc, vma;
+ 	bfd_size_type size;
+ 	struct a2l_data *a2l = data;
++	flagword flags;
+ 
+ 	if (a2l->found)
+ 		return;
+ 
+-	if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0)
++#ifdef bfd_get_section_flags
++	flags = bfd_get_section_flags(abfd, section);
++#else
++	flags = bfd_section_flags(section);
++#endif
++	if ((flags & SEC_ALLOC) == 0)
+ 		return;
+ 
+ 	pc = a2l->addr;
++#ifdef bfd_get_section_vma
+ 	vma = bfd_get_section_vma(abfd, section);
++#else
++	vma = bfd_section_vma(section);
++#endif
++#ifdef bfd_get_section_size
+ 	size = bfd_get_section_size(section);
++#else
++	size = bfd_section_size(section);
++#endif
+ 
+ 	if (pc < vma || pc >= vma + size)
+ 		return;
+-- 
+2.26.2
+

--- a/recipes-kernel/linux/linux-meson64-5.4/0068-UPSTREAM-perf-Make-perf-able-to-build-with-latest-libbfd.patch
+++ b/recipes-kernel/linux/linux-meson64-5.4/0068-UPSTREAM-perf-Make-perf-able-to-build-with-latest-libbfd.patch
@@ -1,0 +1,60 @@
+From 0ada120c883d4f1f6aafd01cf0fbb10d8bbba015 Mon Sep 17 00:00:00 2001
+From: Changbin Du <changbin.du@gmail.com>
+Date: Tue, 28 Jan 2020 23:29:38 +0800
+Subject: [PATCH] perf: Make perf able to build with latest libbfd
+
+libbfd has changed the bfd_section_* macros to inline functions
+bfd_section_<field> since 2019-09-18. See below two commits:
+  o http://www.sourceware.org/ml/gdb-cvs/2019-09/msg00064.html
+  o https://www.sourceware.org/ml/gdb-cvs/2019-09/msg00072.html
+
+This fix make perf able to build with both old and new libbfd.
+
+Signed-off-by: Changbin Du <changbin.du@gmail.com>
+Acked-by: Jiri Olsa <jolsa@redhat.com>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Link: http://lore.kernel.org/lkml/20200128152938.31413-1-changbin.du@gmail.com
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+---
+ tools/perf/util/srcline.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/tools/perf/util/srcline.c b/tools/perf/util/srcline.c
+index 6ccf6f6d09df..5b7d6c16d33f 100644
+--- a/tools/perf/util/srcline.c
++++ b/tools/perf/util/srcline.c
+@@ -193,16 +193,30 @@ static void find_address_in_section(bfd *abfd, asection *section, void *data)
+ 	bfd_vma pc, vma;
+ 	bfd_size_type size;
+ 	struct a2l_data *a2l = data;
++	flagword flags;
+ 
+ 	if (a2l->found)
+ 		return;
+ 
+-	if ((bfd_get_section_flags(abfd, section) & SEC_ALLOC) == 0)
++#ifdef bfd_get_section_flags
++	flags = bfd_get_section_flags(abfd, section);
++#else
++	flags = bfd_section_flags(section);
++#endif
++	if ((flags & SEC_ALLOC) == 0)
+ 		return;
+ 
+ 	pc = a2l->addr;
++#ifdef bfd_get_section_vma
+ 	vma = bfd_get_section_vma(abfd, section);
++#else
++	vma = bfd_section_vma(section);
++#endif
++#ifdef bfd_get_section_size
+ 	size = bfd_get_section_size(section);
++#else
++	size = bfd_section_size(section);
++#endif
+ 
+ 	if (pc < vma || pc >= vma + size)
+ 		return;
+-- 
+2.26.2
+

--- a/recipes-kernel/linux/linux-meson64_5.2.bb
+++ b/recipes-kernel/linux/linux-meson64_5.2.bb
@@ -243,6 +243,7 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;protoc
            file://0231-TEMP-drm-panfrost-kernel-driver-fix-1-2.patch \
            file://0232-TEMP-drm-panfrost-kernel-driver-fix-2-2.patch \
            file://0001-clk-Fix-potential-NULL-dereference-in-clk_fetch_pare.patch \
+           file://0233-UPSTREAM-perf-Make-perf-able-to-build-with-latest-libbfd.patch \
            "
 
 KERNEL_VERSION_SANITY_SKIP="1"

--- a/recipes-kernel/linux/linux-meson64_5.4.bb
+++ b/recipes-kernel/linux/linux-meson64_5.4.bb
@@ -88,6 +88,7 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;protoc
            file://0065-FROMLIST-media-meson-vdec-add-VP9-decoder-support.patch \
            file://0066-FROMLIST-arm64-dts-meson-g12g12-add-syscon-phandle-i.patch \
            file://0067-FROMLIST-media-platform-meson-ao-cec-g12a-add-wakeup.patch \
+           file://0068-UPSTREAM-perf-Make-perf-able-to-build-with-latest-libbfd.patch \
            "
 
 KERNEL_VERSION_SANITY_SKIP="1"


### PR DESCRIPTION
Linux kernel patch makes perf able to build with latest libbfd

Fixes:

| /workdir/build/tmp/work/libretech_ac-poky-linux/perf/1.0-r9/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/9.3.0/ld: /workdir/build/tmp/work/libretech_ac-poky-linux/perf/1.0-r9/perf-1.0/perf-in.o: in function `find_address_in_section':
| /usr/src/debug/perf/1.0-r9/perf-1.0/tools/perf/util/srcline.c:200: undefined reference to `bfd_get_section_flags'
| /workdir/build/tmp/work/libretech_ac-poky-linux/perf/1.0-r9/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/9.3.0/ld: /usr/src/debug/perf/1.0-r9/perf-1.0/tools/perf/util/srcline.c:204: undefined reference to `bfd_get_section_vma'
| /workdir/build/tmp/work/libretech_ac-poky-linux/perf/1.0-r9/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/9.3.0/ld: /usr/src/debug/perf/1.0-r9/perf-1.0/tools/perf/util/srcline.c:205: undefined reference to `bfd_get_section_size'

Signed-off-by: Daniel Gomez <dagmcr@gmail.com>