### PR TITLE
s905-autoscript-multiboot: Fix u-boot reset command

### DIFF
--- a/recipes-bsp/s905-autoscript-multiboot/files/aml_autoscript.cmd
+++ b/recipes-bsp/s905-autoscript-multiboot/files/aml_autoscript.cmd
@@ -8,4 +8,4 @@ setenv start_usb_autoscript "if fatload usb 0 1020000 s905_autoscript; then auto
 setenv upgrade_step "2"
 saveenv
 sleep 1
-reboot
+reset


### PR DESCRIPTION
U-Boot reboot command is 'reset' and not 'reboot'. Therfore, script
fails trying to reboot the board with the wrong command.

Signed-off-by: Daniel Gomez <dagmcr@gmail.com>