### PR TITLE
khadas-vim3: add mainline u-boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Available S922X machines are :
  - hardkernel-odroidn2: .wic image to be booted using vendor u-boot
 
 Available A311D machines are :
- - khadas-vim3: .wic image to be booted using vendor u-boot
+ - khadas-vim : complete bootable .wic sdcard image with mainline U-boot
+ - khadas-vim3-sdboot : .wic image to be booted using vendor u-boot
 
 Available S9xxx machines are :
  - amlogic-s9xxx (all S905 and S905X and S912 machines) : generic non-bootable .wic image to be customized

--- a/conf/machine/khadas-vim3-sdboot.conf
+++ b/conf/machine/khadas-vim3-sdboot.conf
@@ -1,0 +1,7 @@
+# Khadas VIM3 board
+
+require conf/machine/include/amlogic-a311d.inc
+require conf/machine/include/khadas-vim3-dtb.inc
+
+EXTRA_IMAGEDEPENDS += "s905-autoscript s905-autoscript-multiboot"
+IMAGE_BOOT_FILES += " s905_autoscript aml_autoscript aml_autoscript.zip"

--- a/conf/machine/khadas-vim3.conf
+++ b/conf/machine/khadas-vim3.conf
@@ -10,7 +10,7 @@ IMAGE_BOOT_FILES_append = "Image"
 PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"
 PREFERRED_PROVIDER_u-boot = "u-boot-meson-gx"
-PREFERRED_VERSION_u-boot-meson-gx = "2020.04%"
+PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 
 UBOOT_MACHINE = "khadas-vim3_defconfig"
 UBOOT_EXTLINUX = "1"

--- a/conf/machine/khadas-vim3.conf
+++ b/conf/machine/khadas-vim3.conf
@@ -3,5 +3,28 @@
 require conf/machine/include/amlogic-a311d.inc
 require conf/machine/include/khadas-vim3-dtb.inc
 
-EXTRA_IMAGEDEPENDS += "s905-autoscript s905-autoscript-multiboot"
-IMAGE_BOOT_FILES += " s905_autoscript aml_autoscript aml_autoscript.zip"
+KERNEL_IMAGETYPE = "Image"
+IMAGE_BOOT_FILES_remove = "uImage"
+IMAGE_BOOT_FILES_append = "Image"
+
+PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"
+PREFERRED_PROVIDER_u-boot = "u-boot-meson-gx"
+PREFERRED_VERSION_u-boot-meson-gx = "2020.04%"
+
+UBOOT_MACHINE = "khadas-vim3_defconfig"
+UBOOT_EXTLINUX = "1"
+UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
+UBOOT_EXTLINUX_FDT = "../meson-g12b-a311d-khadas-vim3.dts"
+UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
+
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
+       kernel-image \
+       kernel-devicetree \
+       u-boot-meson-gx \
+"
+
+# Generate an SDCard Image
+IMAGE_CLASSES += "image_types_meson"
+
+WKS_FILE = "sdimage-meson.wks"

--- a/recipes-bsp/u-boot/u-boot-common_2020.10.inc
+++ b/recipes-bsp/u-boot/u-boot-common_2020.10.inc
@@ -1,0 +1,15 @@
+HOMEPAGE = "http://www.denx.de/wiki/U-Boot/WebHome"
+SECTION = "bootloaders"
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=5a7450c57ffe5ae63fd732446b988025"
+PE = "1"
+
+# We use the revision in order to avoid having to fetch it from the
+# repo during parse
+SRCREV = "96d66a9b8ce11aae9f8bef5244b83b4740b37644"
+
+SRC_URI = "git://github.com/u-boot/u-boot.git"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"

--- a/recipes-bsp/u-boot/u-boot-meson-gx_2020.10.bb
+++ b/recipes-bsp/u-boot/u-boot-meson-gx_2020.10.bb
@@ -1,0 +1,360 @@
+require u-boot-common_${PV}.inc
+require recipes-bsp/u-boot/u-boot.inc
+
+DEPENDS += "bison-native bc-native dtc-native python3-native amlogic-fip"
+
+PROVIDES = "u-boot"
+
+SRC_URI_append_meson-axg = " \
+       file://0001-board-meson-s400-enable-eMMC-when-booting-from-it.patch \
+"
+
+SRC_URI_append = " \
+	file://acs_tool.py \
+"
+
+deploy_axg () {
+    FIPDIR="${DEPLOY_DIR_IMAGE}/fip/"
+    DESTDIR="${B}/fip"
+
+    mkdir -p ${DESTDIR}
+
+    cp ${FIPDIR}/bl31.img ${DESTDIR}/bl31.img
+    cp ${B}/u-boot.bin ${DESTDIR}/bl33.bin
+
+    ${FIPDIR}/blx_fix.sh ${FIPDIR}/bl30.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl30_zero.bin \
+			 ${FIPDIR}/bl301.bin \
+			 ${DESTDIR}/bl301_zero.bin \
+			 ${DESTDIR}/bl30_new.bin bl30
+    python3 ${WORKDIR}/acs_tool.py ${FIPDIR}/bl2.bin \
+				  ${DESTDIR}/bl2_acs.bin \
+				  ${FIPDIR}/acs.bin 0
+    ${FIPDIR}/blx_fix.sh ${DESTDIR}/bl2_acs.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl2_zero.bin \
+			 ${FIPDIR}/bl21.bin \
+			 ${DESTDIR}/bl21_zero.bin \
+			 ${DESTDIR}/bl2_new.bin bl2
+
+    ${FIPDIR}/aml_encrypt --bl3sig --input ${DESTDIR}/bl30_new.bin --output ${DESTDIR}/bl30_new.bin.enc --level 3 --type bl30
+    ${FIPDIR}/aml_encrypt --bl3sig --input ${DESTDIR}/bl31.img --output ${DESTDIR}/bl31.img.enc --level 3 --type bl31
+    ${FIPDIR}/aml_encrypt --bl3sig --input ${DESTDIR}/bl33.bin --output ${DESTDIR}/bl33.bin.enc --level 3 --type bl33 --compress lz4
+    ${FIPDIR}/aml_encrypt --bl2sig --input ${DESTDIR}/bl2_new.bin --output ${DESTDIR}/bl2.n.bin.sig
+    ${FIPDIR}/aml_encrypt --bootmk --output ${DESTDIR}/u-boot.bin \
+			  --bl2 ${DESTDIR}/bl2.n.bin.sig \
+			  --bl30 ${DESTDIR}/bl30_new.bin.enc \
+			  --bl31 ${DESTDIR}/bl31.img.enc \
+			  --bl33 ${DESTDIR}/bl33.bin.enc \
+			  --level 3
+
+    # SDCard
+    install ${DESTDIR}/u-boot.bin.sd.bin ${DEPLOYDIR}/u-boot.bin.sd.bin
+    # eMMC
+    install ${DESTDIR}/u-boot.bin ${DEPLOYDIR}/u-boot.bin
+    # USB
+    install ${DESTDIR}/u-boot.bin.usb.bl2 ${DEPLOYDIR}/u-boot.bin.usb.bl2
+    install ${DESTDIR}/u-boot.bin.usb.tpl ${DEPLOYDIR}/u-boot.bin.usb.tpl
+}
+
+deploy_gxbb () {
+    FIPDIR="${DEPLOY_DIR_IMAGE}/fip/"
+    DESTDIR="${B}/fip"
+
+    mkdir -p ${DESTDIR}
+
+    cp ${FIPDIR}/bl31.img ${DESTDIR}/bl31.img
+    cp ${B}/u-boot.bin ${DESTDIR}/bl33.bin
+
+    ${FIPDIR}/blx_fix.sh ${FIPDIR}/bl30.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl30_zero.bin \
+			 ${FIPDIR}/bl301.bin \
+			 ${DESTDIR}/bl301_zero.bin \
+			 ${DESTDIR}/bl30_new.bin bl30
+
+    ${FIPDIR}/fip_create --bl30 ${DESTDIR}/bl30_new.bin \
+			 --bl31 ${FIPDIR}/bl31.img \
+			 --bl33 ${DESTDIR}/bl33.bin \
+			 ${DESTDIR}/fip.bin
+
+    python3 ${WORKDIR}/acs_tool.py ${FIPDIR}/bl2.bin \
+				  ${DESTDIR}/bl2_acs.bin \
+				  ${FIPDIR}/acs.bin 0
+
+    ${FIPDIR}/blx_fix.sh ${DESTDIR}/bl2_acs.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl2_zero.bin \
+			 ${FIPDIR}/bl21.bin \
+			 ${DESTDIR}/bl21_zero.bin \
+			 ${DESTDIR}/bl2_new.bin bl2
+
+    cat ${DESTDIR}/bl2_new.bin ${DESTDIR}/fip.bin > ${DESTDIR}/boot_new.bin
+
+    ${FIPDIR}/aml_encrypt_gxb --bootsig --input ${DESTDIR}/boot_new.bin \
+			      --output ${DESTDIR}/u-boot.bin
+
+    # SDCard
+    install ${DESTDIR}/u-boot.bin.sd.bin ${DEPLOYDIR}/u-boot.bin.sd.bin
+    # eMMC
+    install ${DESTDIR}/u-boot.bin ${DEPLOYDIR}/u-boot.bin
+    # USB
+    install ${DESTDIR}/u-boot.bin.usb.bl2 ${DEPLOYDIR}/u-boot.bin.usb.bl2
+    install ${DESTDIR}/u-boot.bin.usb.tpl ${DEPLOYDIR}/u-boot.bin.usb.tpl
+}
+
+deploy_gxl () {
+    FIPDIR="${DEPLOY_DIR_IMAGE}/fip/"
+    DESTDIR="${B}/fip"
+    
+    mkdir -p ${DESTDIR}
+
+    cp ${FIPDIR}/bl31.img ${DESTDIR}/bl31.img
+    cp ${B}/u-boot.bin ${DESTDIR}/bl33.bin
+
+    ${FIPDIR}/blx_fix.sh ${FIPDIR}/bl30.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl30_zero.bin \
+			 ${FIPDIR}/bl301.bin \
+			 ${DESTDIR}/bl301_zero.bin \
+			 ${DESTDIR}/bl30_new.bin bl30
+    python3 ${WORKDIR}/acs_tool.py ${FIPDIR}/bl2.bin \
+				  ${DESTDIR}/bl2_acs.bin \
+				  ${FIPDIR}/acs.bin 0
+    ${FIPDIR}/blx_fix.sh ${DESTDIR}/bl2_acs.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl2_zero.bin \
+			 ${FIPDIR}/bl21.bin \
+			 ${DESTDIR}/bl21_zero.bin \
+			 ${DESTDIR}/bl2_new.bin bl2
+
+    ${FIPDIR}/aml_encrypt_gxl --bl3enc --input ${DESTDIR}/bl30_new.bin
+    ${FIPDIR}/aml_encrypt_gxl --bl3enc --input ${DESTDIR}/bl31.img
+    ${FIPDIR}/aml_encrypt_gxl --bl3enc --input ${DESTDIR}/bl33.bin
+    ${FIPDIR}/aml_encrypt_gxl --bl2sig --input ${DESTDIR}/bl2_new.bin --output ${DESTDIR}/bl2.n.bin.sig
+    ${FIPDIR}/aml_encrypt_gxl --bootmk --output ${DESTDIR}/u-boot.bin \
+			      --bl2 ${DESTDIR}/bl2.n.bin.sig \
+			      --bl30 ${DESTDIR}/bl30_new.bin.enc \
+			      --bl31 ${DESTDIR}/bl31.img.enc \
+			      --bl33 ${DESTDIR}/bl33.bin.enc
+
+    # SDCard
+    install ${DESTDIR}/u-boot.bin.sd.bin ${DEPLOYDIR}/u-boot.bin.sd.bin
+    # eMMC
+    install ${DESTDIR}/u-boot.bin ${DEPLOYDIR}/u-boot.bin
+    # USB
+    install ${DESTDIR}/u-boot.bin.usb.bl2 ${DEPLOYDIR}/u-boot.bin.usb.bl2
+    install ${DESTDIR}/u-boot.bin.usb.tpl ${DEPLOYDIR}/u-boot.bin.usb.tpl
+} 
+
+deploy_odroidc2 () {
+    FIPDIR="${DEPLOY_DIR_IMAGE}/fip/"
+    DESTDIR="${B}/fip"
+    
+    mkdir -p ${DESTDIR}
+
+    ${FIPDIR}/fip_create --bl30 ${FIPDIR}/bl30.bin \
+			 --bl301 ${FIPDIR}/bl301.bin \
+			 --bl31 ${FIPDIR}/bl31.bin \
+			 --bl33 ${B}/u-boot.bin \
+			 ${DESTDIR}/fip.bin
+    ${FIPDIR}/fip_create --dump ${DESTDIR}/fip.bin
+    cat ${FIPDIR}/bl2.package ${DESTDIR}/fip.bin > ${DESTDIR}/boot_new.bin
+
+    ${FIPDIR}/aml_encrypt_gxb --bootsig \
+			      --input ${DESTDIR}/boot_new.bin \
+			      --output ${DESTDIR}/u-boot.img
+
+    install ${DESTDIR}/u-boot.img ${DEPLOYDIR}/u-boot.img
+} 
+
+deploy_g12a () {
+    FIPDIR="${DEPLOY_DIR_IMAGE}/fip/"
+    DESTDIR="${B}/fip"
+    
+    mkdir -p ${DESTDIR}
+
+    cp ${FIPDIR}/bl31.img ${DESTDIR}/bl31.img
+    cp ${B}/u-boot.bin ${DESTDIR}/bl33.bin
+
+    ${FIPDIR}/blx_fix.sh ${FIPDIR}/bl30.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl30_zero.bin \
+			 ${FIPDIR}/bl301.bin \
+			 ${DESTDIR}/bl301_zero.bin \
+			 ${DESTDIR}/bl30_new.bin bl30
+
+    ${FIPDIR}/blx_fix.sh ${FIPDIR}/bl2.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl2_zero.bin \
+			 ${FIPDIR}/acs.bin \
+			 ${DESTDIR}/bl21_zero.bin \
+			 ${DESTDIR}/bl2_new.bin bl2
+
+    ${FIPDIR}/aml_encrypt_g12a --bl30sig \
+		    --input ${DESTDIR}/bl30_new.bin \
+		    --output ${DESTDIR}/bl30_new.bin.g12.enc \
+		    --level v3
+    ${FIPDIR}/aml_encrypt_g12a --bl3sig \
+		    --input ${DESTDIR}/bl30_new.bin.g12.enc \
+		    --output ${DESTDIR}/bl30_new.bin.enc \
+		    --level v3 --type bl30
+    ${FIPDIR}/aml_encrypt_g12a --bl3sig \
+		    --input ${FIPDIR}/bl31.img \
+		    --output ${DESTDIR}/bl31.img.enc \
+		    --level v3 --type bl31
+    ${FIPDIR}/aml_encrypt_g12a --bl3sig \
+		    --input ${DESTDIR}/bl33.bin \
+		    --compress lz4 \
+		    --output ${DESTDIR}/bl33.bin.enc \
+		    --level v3 --type bl33
+    ${FIPDIR}/aml_encrypt_g12a --bl2sig \
+		    --input ${DESTDIR}/bl2_new.bin \
+		    --output ${DESTDIR}/bl2.n.bin.sig
+
+    if [ -e ${FIPDIR}/lpddr3_1d.fw ]
+    then
+            ${FIPDIR}/aml_encrypt_g12a --bootmk \
+                    --output ${DESTDIR}/u-boot.bin \
+                    --bl2 ${DESTDIR}/bl2.n.bin.sig \
+                    --bl30 ${DESTDIR}/bl30_new.bin.enc \
+                    --bl31 ${DESTDIR}/bl31.img.enc \
+                    --bl33 ${DESTDIR}/bl33.bin.enc \
+                    --ddrfw1 ${FIPDIR}/ddr4_1d.fw \
+                    --ddrfw2 ${FIPDIR}/ddr4_2d.fw \
+                    --ddrfw3 ${FIPDIR}/ddr3_1d.fw \
+                    --ddrfw4 ${FIPDIR}/piei.fw \
+                    --ddrfw5 ${FIPDIR}/lpddr4_1d.fw \
+                    --ddrfw6 ${FIPDIR}/lpddr4_2d.fw \
+                    --ddrfw7 ${FIPDIR}/diag_lpddr4.fw \
+                    --ddrfw8 ${FIPDIR}/aml_ddr.fw \
+                    --ddrfw9 ${FIPDIR}/lpddr3_1d.fw \
+                    --level v3
+    else
+            ${FIPDIR}/aml_encrypt_g12a --bootmk \
+                    --output ${DESTDIR}/u-boot.bin \
+                    --bl2 ${DESTDIR}/bl2.n.bin.sig \
+                    --bl30 ${DESTDIR}/bl30_new.bin.enc \
+                    --bl31 ${DESTDIR}/bl31.img.enc \
+                    --bl33 ${DESTDIR}/bl33.bin.enc \
+                    --ddrfw1 ${FIPDIR}/ddr4_1d.fw \
+                    --ddrfw2 ${FIPDIR}/ddr4_2d.fw \
+                    --ddrfw3 ${FIPDIR}/ddr3_1d.fw \
+                    --ddrfw4 ${FIPDIR}/piei.fw \
+                    --ddrfw5 ${FIPDIR}/lpddr4_1d.fw \
+                    --ddrfw6 ${FIPDIR}/lpddr4_2d.fw \
+                    --ddrfw7 ${FIPDIR}/diag_lpddr4.fw \
+                    --ddrfw8 ${FIPDIR}/aml_ddr.fw \
+                    --level v3
+    fi
+
+    # SDCard
+    install ${DESTDIR}/u-boot.bin.sd.bin ${DEPLOYDIR}/u-boot.bin.sd.bin
+    # eMMC
+    install ${DESTDIR}/u-boot.bin ${DEPLOYDIR}/u-boot.bin
+    # USB
+    install ${DESTDIR}/u-boot.bin.usb.bl2 ${DEPLOYDIR}/u-boot.bin.usb.bl2
+    install ${DESTDIR}/u-boot.bin.usb.tpl ${DEPLOYDIR}/u-boot.bin.usb.tpl
+}
+
+deploy_g12b () {
+    FIPDIR="${DEPLOY_DIR_IMAGE}/fip/"
+    DESTDIR="${B}/fip"
+    
+    mkdir -p ${DESTDIR}
+
+    cp ${FIPDIR}/bl31.img ${DESTDIR}/bl31.img
+    cp ${B}/u-boot.bin ${DESTDIR}/bl33.bin
+
+    ${FIPDIR}/blx_fix.sh ${FIPDIR}/bl30.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl30_zero.bin \
+			 ${FIPDIR}/bl301.bin \
+			 ${DESTDIR}/bl301_zero.bin \
+			 ${DESTDIR}/bl30_new.bin bl30
+
+    ${FIPDIR}/blx_fix.sh ${FIPDIR}/bl2.bin \
+			 ${DESTDIR}/zero_tmp \
+			 ${DESTDIR}/bl2_zero.bin \
+			 ${FIPDIR}/acs.bin \
+			 ${DESTDIR}/bl21_zero.bin \
+			 ${DESTDIR}/bl2_new.bin bl2
+
+    ${FIPDIR}/aml_encrypt_g12b --bl30sig \
+		    --input ${DESTDIR}/bl30_new.bin \
+		    --output ${DESTDIR}/bl30_new.bin.g12.enc \
+		    --level v3
+    ${FIPDIR}/aml_encrypt_g12b --bl3sig \
+		    --input ${DESTDIR}/bl30_new.bin.g12.enc \
+		    --output ${DESTDIR}/bl30_new.bin.enc \
+		    --level v3 --type bl30
+    ${FIPDIR}/aml_encrypt_g12b --bl3sig \
+		    --input ${FIPDIR}/bl31.img \
+		    --output ${DESTDIR}/bl31.img.enc \
+		    --level v3 --type bl31
+    ${FIPDIR}/aml_encrypt_g12b --bl3sig \
+		    --input ${DESTDIR}/bl33.bin \
+		    --compress lz4 \
+		    --output ${DESTDIR}/bl33.bin.enc \
+		    --level v3 --type bl33
+    ${FIPDIR}/aml_encrypt_g12b --bl2sig \
+		    --input ${DESTDIR}/bl2_new.bin \
+		    --output ${DESTDIR}/bl2.n.bin.sig
+
+    if [ -e ${FIPDIR}/lpddr3_1d.fw ]
+    then
+            ${FIPDIR}/aml_encrypt_g12b --bootmk \
+                    --output ${DESTDIR}/u-boot.bin \
+                    --bl2 ${DESTDIR}/bl2.n.bin.sig \
+                    --bl30 ${DESTDIR}/bl30_new.bin.enc \
+                    --bl31 ${DESTDIR}/bl31.img.enc \
+                    --bl33 ${DESTDIR}/bl33.bin.enc \
+                    --ddrfw1 ${FIPDIR}/ddr4_1d.fw \
+                    --ddrfw2 ${FIPDIR}/ddr4_2d.fw \
+                    --ddrfw3 ${FIPDIR}/ddr3_1d.fw \
+                    --ddrfw4 ${FIPDIR}/piei.fw \
+                    --ddrfw5 ${FIPDIR}/lpddr4_1d.fw \
+                    --ddrfw6 ${FIPDIR}/lpddr4_2d.fw \
+                    --ddrfw7 ${FIPDIR}/diag_lpddr4.fw \
+                    --ddrfw8 ${FIPDIR}/aml_ddr.fw \
+                    --ddrfw9 ${FIPDIR}/lpddr3_1d.fw \
+                    --level v3
+    else
+            ${FIPDIR}/aml_encrypt_g12b --bootmk \
+                    --output ${DESTDIR}/u-boot.bin \
+                    --bl2 ${DESTDIR}/bl2.n.bin.sig \
+                    --bl30 ${DESTDIR}/bl30_new.bin.enc \
+                    --bl31 ${DESTDIR}/bl31.img.enc \
+                    --bl33 ${DESTDIR}/bl33.bin.enc \
+                    --ddrfw1 ${FIPDIR}/ddr4_1d.fw \
+                    --ddrfw2 ${FIPDIR}/ddr4_2d.fw \
+                    --ddrfw3 ${FIPDIR}/ddr3_1d.fw \
+                    --ddrfw4 ${FIPDIR}/piei.fw \
+                    --ddrfw5 ${FIPDIR}/lpddr4_1d.fw \
+                    --ddrfw6 ${FIPDIR}/lpddr4_2d.fw \
+                    --ddrfw7 ${FIPDIR}/diag_lpddr4.fw \
+                    --ddrfw8 ${FIPDIR}/aml_ddr.fw \
+                    --level v3
+    fi
+
+    # SDCard
+    install ${DESTDIR}/u-boot.bin.sd.bin ${DEPLOYDIR}/u-boot.bin.sd.bin
+    # eMMC
+    install ${DESTDIR}/u-boot.bin ${DEPLOYDIR}/u-boot.bin
+    # USB
+    install ${DESTDIR}/u-boot.bin.usb.bl2 ${DEPLOYDIR}/u-boot.bin.usb.bl2
+    install ${DESTDIR}/u-boot.bin.usb.tpl ${DEPLOYDIR}/u-boot.bin.usb.tpl
+}
+
+DEPLOY_COMMAND_meson-axg = "deploy_axg"
+DEPLOY_COMMAND_meson-g12a = "deploy_g12a"
+DEPLOY_COMMAND_meson-sm1 = "deploy_g12a"
+DEPLOY_COMMAND_meson-g12b = "deploy_g12b"
+DEPLOY_COMMAND_meson-gxl = "deploy_gxl"
+DEPLOY_COMMAND_meson-gxbb = "deploy_gxbb"
+DEPLOY_COMMAND_hardkernel-odroidc2 = "deploy_odroidc2"
+
+do_deploy_append_meson-gx () {
+	${DEPLOY_COMMAND}
+}


### PR DESCRIPTION
Add mainline-uboot support for khadas-vim3, and rename vendor u-boot
target to khadas-vim3-sdboot to match other machines.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>