### PR TITLE
khadas-vim3: use linux-yocto-dev, FIT image, fix WIC etc.

### DIFF
--- a/classes/image_types_meson.bbclass
+++ b/classes/image_types_meson.bbclass
@@ -2,6 +2,9 @@ inherit image_types
 
 WIC_COMMAND_meson-gxl = "wic_command_meson_gxl"
 WIC_COMMAND_meson-gxm = "wic_command_meson_gxl"
+WIC_COMMAND_meson-g12a = "wic_command_meson_gxl"
+WIC_COMMAND_meson-g12b = "wic_command_meson_gxl"
+WIC_COMMAND_meson-sm1 = "wic_command_meson_gxl"
 WIC_COMMAND_meson-gxbb = "wic_command_meson_gxbb"
 WIC_COMMAND_hardkernel-odroidc2 = "wic_command_odroidc2"
 WIC_COMMAND_friendlyelec-nanopik2 = "wic_command_nanopik2"

--- a/conf/machine/include/khadas-vim3-dtb.inc
+++ b/conf/machine/include/khadas-vim3-dtb.inc
@@ -1,4 +1,5 @@
-# Khadas VIM3
+# Khadas VIM3 (supports both A311D and S922X version)
 
 KERNEL_DEVICETREE += "amlogic/meson-g12b-a311d-khadas-vim3.dtb"
-IMAGE_BOOT_FILES += "meson-g12b-a311d-khadas-vim3.dtb:meson-g12b-a311d-khadas-vim3.dtb"
+KERNEL_DEVICETREE += "amlogic/meson-g12b-s922x-khadas-vim3.dtb"
+IMAGE_BOOT_FILES += "meson-g12b-a311d-khadas-vim3.dtb:meson-g12b-s922x-khadas-vim3.dtb"

--- a/conf/machine/khadas-vim3.conf
+++ b/conf/machine/khadas-vim3.conf
@@ -3,9 +3,17 @@
 require conf/machine/include/amlogic-a311d.inc
 require conf/machine/include/khadas-vim3-dtb.inc
 
-KERNEL_IMAGETYPE = "Image"
-IMAGE_BOOT_FILES_remove = "uImage"
-IMAGE_BOOT_FILES_append = " Image"
+#
+# Kernel
+# - Use standard linux-yocto recipe, drop custom uImage, build FIT image
+#
+PREFERRED_PROVIDER_virtual/kernel_meson-gx ?= "linux-yocto-dev"
+KMACHINE_meson-gx = "meson-gx"
+KERNEL_CLASSES_meson-gx = "kernel kernel-fitimage"
+KERNEL_IMAGETYPE_meson-gx = "Image"
+KERNEL_IMAGETYPES_append_meson-gx = " fitImage"
+# undo misc. meta-meson defaults
+IMAGE_BOOT_FILES_remove_meson-gx = "uImage"
 
 PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"

--- a/recipes-bsp/u-boot/u-boot-meson-gx/fit.cfg
+++ b/recipes-bsp/u-boot/u-boot-meson-gx/fit.cfg
@@ -1,0 +1,7 @@
+CONFIG_FIT=y
+CONFIG_FIT_SIGNATURE=y
+CONFIG_FIT_VERBOSE=y
+
+# don't break legacy uImage support (until device-types are updated for amlogic)
+# WARNING this allows option to bypass FIT image signature checking
+CONFIG_LEGACY_IMAGE_FORMAT=y

--- a/recipes-bsp/u-boot/u-boot-meson-gx_2020.10.bb
+++ b/recipes-bsp/u-boot/u-boot-meson-gx_2020.10.bb
@@ -7,6 +7,7 @@ PROVIDES = "u-boot virtual/bootloader"
 
 SRC_URI_append = " \
 	file://acs_tool.py \
+	file://fit.cfg \
 "
 
 deploy_axg () {

--- a/recipes-kernel/linux/linux-yocto%.bbappend
+++ b/recipes-kernel/linux/linux-yocto%.bbappend
@@ -2,8 +2,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}:"
 
 SRC_URI += "file://meson64-kmeta;type=kmeta;destsuffix=meson64-kmeta"
 
-COMPATIBLE_MACHINE_khadas-vim3 = "khadas-vim3"
-KMACHINE_khadas-vim3 = "meson-gx"
+COMPATIBLE_MACHINE_append_meson-gx = "|khadas-vim3"
+KMACHINE_meson-gx = "meson-gx"
 
 LINUX_VERSION_EXTENSION_append_meson-gx = "-meson64"
 
@@ -12,3 +12,6 @@ SERIAL_CONSOLES = "115200;ttyAML0"
 # Add HDMI output support if display output is required
 KERNEL_FEATURES_append = "${@bb.utils.contains_any('DISTRO_FEATURES', 'x11 wayland', \
     ' cfg/meson-hdmi.scc', '', d)}"
+
+# Enable virt options, needed for docker, LXC, etc.
+include ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'recipes-kernel/linux/linux-yocto_virtualization.inc', '', d)}


### PR DESCRIPTION
Handful of cleanups, fixes to use linux-yocto-dev kernel with FIT support.  
Initial focus on khadas-vim3, but done in a way to be generic for all of `meson-gx` machines that support mainline u-boot.
