### PR TITLE
Fixup linux-yocto to build for -sdboot targets

### DIFF
--- a/classes/kernel-uimage-meson.bbclass
+++ b/classes/kernel-uimage-meson.bbclass
@@ -11,7 +11,7 @@ python __anonymous () {
 
 do_uboot_mkimage() {
 	if test "x${KERNEL_IMAGETYPE}" = "xuImage" ; then
-		uboot-mkimage -A ${UBOOT_ARCH} -O linux -T kernel -C none -a ${UBOOT_LOADADDRESS} -e ${UBOOT_ENTRYSYMBOL} -n "${DISTRO_NAME}/${PV}/${MACHINE}" -d ${B}/arch/${ARCH}/boot/Image ${B}/arch/${ARCH}/boot/uImage
+		uboot-mkimage -A ${UBOOT_ARCH} -O linux -T kernel -C none -a ${UBOOT_LOADADDRESS} -e ${UBOOT_ENTRYPOINT} -n "${DISTRO_NAME}/${PV}/${MACHINE}" -d ${B}/arch/${ARCH}/boot/Image ${B}/arch/${ARCH}/boot/uImage
 	fi
 }
 


### PR DESCRIPTION
Hey guys,

Sorry I've not been here for a while, but coming back to do some maintenance on the linux-yocto recipes for the VIM3.

Fixup linux-yocto_% to have a COMPATIBLE_MACHINE for <target>-sdboot targets.
Also fix do_uboot_mkimage where UBOOT_ENTRYPOINT is not defined.

I had an issue where uboot mkimage would fail due to a missing UBOOT_ENTRYSYMBOL was not defined.  I fixed this by replicating what us done in the base kernel-umage class.  Not 100% if this is correct, but it works for me on my VIM3.

Cheers

/Matt