### PR TITLE
Remove dupliacte include of linux-yocto-virtualization.inc

### DIFF
--- a/recipes-kernel/linux/linux-yocto%.bbappend
+++ b/recipes-kernel/linux/linux-yocto%.bbappend
@@ -15,6 +15,3 @@ KERNEL_FEATURES_append = "${@bb.utils.contains_any('DISTRO_FEATURES', 'x11 wayla
 
 KERNEL_FEATURES_append = "${@bb.utils.contains('DISTRO_FEATURES', 'pci', \
     ' cfg/meson-pci.scc', '', d)}"
-
-# Enable virt options, needed for docker, LXC, etc.
-include ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'recipes-kernel/linux/linux-yocto_virtualization.inc', '', d)}


### PR DESCRIPTION
Including linux-yocto-virtualization.inc in the linix-yocto recipes is not needed as it is pulled in for both linux-yocto-5.x and
linux-yocto-dev from the meta-virtualization recipes.

Before removing this, there were a number of "WARNING: Duplicate inclusion for ..." warnings in the build.

@khilman I know you committed this in an earlier patch set, can you review that you are happy with this?

I have tested using both linux-yocto-5.4 and linux-yocto-5.8 (from the master Poky branch) and docker works fine for me.  I have not tested on linux-yocto-dev, but from code inspection I believe it should work fine.

