### PR TITLE
Use .dtb instead of .dts in boot config

### DIFF
--- a/conf/machine/khadas-vim3.conf
+++ b/conf/machine/khadas-vim3.conf
@@ -23,7 +23,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 UBOOT_MACHINE = "khadas-vim3_defconfig"
 UBOOT_EXTLINUX = "1"
 UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
-UBOOT_EXTLINUX_FDT = "../meson-g12b-a311d-khadas-vim3.dts"
+UBOOT_EXTLINUX_FDT = "../meson-g12b-a311d-khadas-vim3.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \


### PR DESCRIPTION
Use the binary FDT instead of the device tree source when booting.

The board boots now without having to modifying boot params after flashing.

A question, how to I modify the device-tree with fdt set now before booting?  I have a quick scan of the web and can't find anything obvious.