### PR TITLE
RFC: FIT w/kernel, all DTBs, ramdisk and u-boot script

### DIFF
--- a/conf/machine/amlogic-fit.conf
+++ b/conf/machine/amlogic-fit.conf
@@ -1,0 +1,54 @@
+#
+# Build an upstream yocto kernel (linux-yocto-dev) as a FIT image
+# including DTBs for all supported boards and ramdisk.
+#
+# Can be booted on any board running mainline u-boot with FIT support
+# u-boot will have an $fdtfile env variable which can be used to select
+# the right DT config from the FIT image.
+#
+# To boot this FIT image in u-boot (see u-boot requirements below)
+#
+# - load FIT image into memory at $loadaddr
+#
+# - tweak the $fdtfile (replace '/' with '_')
+#   => setexpr fdtfile gsub '/' '_'
+#
+# - boot FIT image using modified $fdtfile to select the right FIT config
+#   =>  bootm ${loadaddr}#conf@${fdtfile}
+#
+# u-boot requirements:
+#
+# FIT support:
+#   CONFIG_FIT=y
+#   CONFIG_FIT_SIGNATURE=y
+#   CONFIG_FIT_VERBOSE=y
+#
+# setexpr support
+#   CONFIG_CMD_SETEXPR=y
+#
+#   This is needed because $fdtfile in u-boot env has a `/` which is
+#   converted into a '_' when FIT image configs are created.
+#
+
+# include all currently supported S9xxx machine.
+require conf/machine/amlogic-s9xxx.conf
+
+#
+# Kernel
+# - Use standard linux-yocto-dev recipe, drop custom uImage, build FIT image
+#
+PREFERRED_PROVIDER_virtual/kernel_meson-gx ?= "linux-yocto-dev"
+KMACHINE_meson-gx = "meson-gx"
+KERNEL_CLASSES_meson-gx = "kernel kernel-fitimage"
+KERNEL_IMAGETYPE_meson-gx = "Image"
+KERNEL_IMAGETYPES_append_meson-gx = " fitImage"
+# undo misc. meta-meson defaults
+IMAGE_BOOT_FILES_remove_meson-gx = "uImage"
+
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
+       kernel-image \
+       kernel-devicetree \
+"
+
+# include initrd into FIT image
+INITRAMFS_IMAGE = "amlogic-image-headless-initrd"

--- a/recipes-kernel/linux/linux-yocto%.bbappend
+++ b/recipes-kernel/linux/linux-yocto%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}:"
 
 SRC_URI += "file://meson64-kmeta;type=kmeta;destsuffix=meson64-kmeta"
 
-COMPATIBLE_MACHINE_append_meson-gx = "|khadas-vim3"
+COMPATIBLE_MACHINE_append_meson-gx = "|amlogic-fit|khadas-vim3"
 KMACHINE_meson-gx = "meson-gx"
 
 LINUX_VERSION_EXTENSION_append_meson-gx = "-meson64"


### PR DESCRIPTION
The goal here is to create a single FIT image for all 64-bit platforms.  It contains a single kernel, but DTBs for all the boards supported by amlogic-s9xxx.conf.  (see the amlogic-fit.conf for all the details.)

Since I'm not really an OE expert, the main question I have is whether the right way to do this is using a new $MACHINE like this (amlogic-fit), or should I be doing this by using a new image class?  