### PR TITLE
khadas-vim3l: add mainline-uboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Available A311D machines are :
  - khadas-vim3-sdboot : .wic image to be booted using vendor u-boot
 
 Available S905X3/D3 machines are :
- - khadas-vim3l : .wic image to be booted using vendor u-boot
+ - khadas-vim3l : complete bootable .wic sdcard image with mainline U-boot
+ - khadas-vim3l-sdboot : .wic image to be booted using vendor u-boot
  - seirobotics-sei610: .wic image to be booted using vendor u-boot
 
 Available S9xxx machines are :

--- a/conf/machine/khadas-vim3l-sdboot.conf
+++ b/conf/machine/khadas-vim3l-sdboot.conf
@@ -1,0 +1,7 @@
+# Khadas VIM3L board
+
+require conf/machine/include/amlogic-s905d3.inc
+require conf/machine/include/khadas-vim3l-dtb.inc
+
+EXTRA_IMAGEDEPENDS += "s905-autoscript s905-autoscript-multiboot"
+IMAGE_BOOT_FILES += " s905_autoscript aml_autoscript aml_autoscript.zip"

--- a/conf/machine/khadas-vim3l.conf
+++ b/conf/machine/khadas-vim3l.conf
@@ -3,5 +3,28 @@
 require conf/machine/include/amlogic-s905d3.inc
 require conf/machine/include/khadas-vim3l-dtb.inc
 
-EXTRA_IMAGEDEPENDS += "s905-autoscript s905-autoscript-multiboot"
-IMAGE_BOOT_FILES += " s905_autoscript aml_autoscript aml_autoscript.zip"
+KERNEL_IMAGETYPE = "Image"
+IMAGE_BOOT_FILES_remove = "uImage"
+IMAGE_BOOT_FILES_append = "Image"
+
+PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"
+PREFERRED_PROVIDER_u-boot = "u-boot-meson-gx"
+PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
+
+UBOOT_MACHINE = "khadas-vim3l_defconfig"
+UBOOT_EXTLINUX = "1"
+UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
+UBOOT_EXTLINUX_FDT = "../meson-sm1-khadas-vim3l.dtb"
+UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
+
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
+       kernel-image \
+       kernel-devicetree \
+       u-boot-meson-gx \
+"
+
+# Generate an SDCard Image
+IMAGE_CLASSES += "image_types_meson"
+
+WKS_FILE = "sdimage-meson.wks"


### PR DESCRIPTION
Convert khadas-vim3l machine to use mainline u-boot.  Vendor u-boot
machine renamed to khadas-vim3l-sdboot to match other machines.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>