### PR TITLE
u-boot: add dynamic PCIe support

### DIFF
--- a/recipes-bsp/u-boot/u-boot-meson-gx/0001-ARM-dts-sync-amlogic-G12A-SM1-DT-from-Linux-5.9-rc1.patch
+++ b/recipes-bsp/u-boot/u-boot-meson-gx/0001-ARM-dts-sync-amlogic-G12A-SM1-DT-from-Linux-5.9-rc1.patch
@@ -1,0 +1,634 @@
+1110e49e3435 ARM: dts: sync amlogic G12A/SM1 DT from Linux 5.9-rc1
+ arch/arm/dts/meson-g12-common.dtsi            |  55 ++++---
+ arch/arm/dts/meson-g12b-odroid-n2.dts         | 136 +++++++++++++++++-
+ arch/arm/dts/meson-khadas-vim3.dtsi           |  26 +++-
+ arch/arm/dts/meson-sm1-khadas-vim3l.dts       |  92 ++++++++++++
+ arch/arm/dts/meson-sm1-odroid-c4.dts          |  88 ++++++++++++
+ include/dt-bindings/clock/g12a-clkc.h         |   2 +
+ .../dt-bindings/sound/meson-g12a-toacodec.h   |  10 ++
+ 7 files changed, 385 insertions(+), 24 deletions(-)
+ create mode 100644 include/dt-bindings/sound/meson-g12a-toacodec.h
+
+diff --git a/arch/arm/dts/meson-g12-common.dtsi b/arch/arm/dts/meson-g12-common.dtsi
+index 593a006f4b7b..1e83ec5b8c91 100644
+--- a/arch/arm/dts/meson-g12-common.dtsi
++++ b/arch/arm/dts/meson-g12-common.dtsi
+@@ -52,6 +52,39 @@
+ 		secure-monitor = <&sm>;
+ 	};
+ 
++	gpu_opp_table: gpu-opp-table {
++		compatible = "operating-points-v2";
++
++		opp-124999998 {
++			opp-hz = /bits/ 64 <124999998>;
++			opp-microvolt = <800000>;
++		};
++		opp-249999996 {
++			opp-hz = /bits/ 64 <249999996>;
++			opp-microvolt = <800000>;
++		};
++		opp-285714281 {
++			opp-hz = /bits/ 64 <285714281>;
++			opp-microvolt = <800000>;
++		};
++		opp-399999994 {
++			opp-hz = /bits/ 64 <399999994>;
++			opp-microvolt = <800000>;
++		};
++		opp-499999992 {
++			opp-hz = /bits/ 64 <499999992>;
++			opp-microvolt = <800000>;
++		};
++		opp-666666656 {
++			opp-hz = /bits/ 64 <666666656>;
++			opp-microvolt = <800000>;
++		};
++		opp-799999987 {
++			opp-hz = /bits/ 64 <799999987>;
++			opp-microvolt = <800000>;
++		};
++	};
++
+ 	psci {
+ 		compatible = "arm,psci-1.0";
+ 		method = "smc";
+@@ -185,8 +218,10 @@
+ 			interrupt-names = "macirq";
+ 			clocks = <&clkc CLKID_ETH>,
+ 				 <&clkc CLKID_FCLK_DIV2>,
+-				 <&clkc CLKID_MPLL2>;
+-			clock-names = "stmmaceth", "clkin0", "clkin1";
++				 <&clkc CLKID_MPLL2>,
++				 <&clkc CLKID_FCLK_DIV2>;
++			clock-names = "stmmaceth", "clkin0", "clkin1",
++				      "timing-adjustment";
+ 			rx-fifo-depth = <4096>;
+ 			tx-fifo-depth = <2048>;
+ 			status = "disabled";
+@@ -2360,21 +2395,7 @@
+ 			interrupt-names = "job", "mmu", "gpu";
+ 			clocks = <&clkc CLKID_MALI>;
+ 			resets = <&reset RESET_DVALIN_CAPB3>, <&reset RESET_DVALIN>;
+-
+-			/*
+-			 * Mali clocking is provided by two identical clock paths
+-			 * MALI_0 and MALI_1 muxed to a single clock by a glitch
+-			 * free mux to safely change frequency while running.
+-			 */
+-			assigned-clocks = <&clkc CLKID_MALI_0_SEL>,
+-					  <&clkc CLKID_MALI_0>,
+-					  <&clkc CLKID_MALI>; /* Glitch free mux */
+-			assigned-clock-parents = <&clkc CLKID_FCLK_DIV2P5>,
+-						 <0>, /* Do Nothing */
+-						 <&clkc CLKID_MALI_0>;
+-			assigned-clock-rates = <0>, /* Do Nothing */
+-					       <800000000>,
+-					       <0>; /* Do Nothing */
++			operating-points-v2 = <&gpu_opp_table>;
+ 			#cooling-cells = <2>;
+ 		};
+ 	};
+diff --git a/arch/arm/dts/meson-g12b-odroid-n2.dts b/arch/arm/dts/meson-g12b-odroid-n2.dts
+index 169ea283d4ee..34fffa6d859d 100644
+--- a/arch/arm/dts/meson-g12b-odroid-n2.dts
++++ b/arch/arm/dts/meson-g12b-odroid-n2.dts
+@@ -9,6 +9,7 @@
+ #include "meson-g12b-s922x.dtsi"
+ #include <dt-bindings/input/input.h>
+ #include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/sound/meson-g12a-toacodec.h>
+ #include <dt-bindings/sound/meson-g12a-tohdmitx.h>
+ 
+ / {
+@@ -20,6 +21,14 @@
+ 		ethernet0 = &ethmac;
+ 	};
+ 
++	dioo2133: audio-amplifier-0 {
++		compatible = "simple-audio-amplifier";
++		enable-gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
++		VCC-supply = <&vcc_5v>;
++		sound-name-prefix = "U19";
++		status = "okay";
++	};
++
+ 	chosen {
+ 		stdout-path = "serial0:115200n8";
+ 	};
+@@ -209,11 +218,42 @@
+ 	sound {
+ 		compatible = "amlogic,axg-sound-card";
+ 		model = "G12B-ODROID-N2";
+-		audio-aux-devs = <&tdmout_b>;
++		audio-widgets = "Line", "Lineout";
++		audio-aux-devs = <&tdmout_b>, <&tdmout_c>, <&tdmin_a>,
++				 <&tdmin_b>, <&tdmin_c>, <&tdmin_lb>,
++				 <&dioo2133>;
+ 		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
+ 				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
+ 				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
+-				"TDM_B Playback", "TDMOUT_B OUT";
++				"TDM_B Playback", "TDMOUT_B OUT",
++				"TDMOUT_C IN 0", "FRDDR_A OUT 2",
++				"TDMOUT_C IN 1", "FRDDR_B OUT 2",
++				"TDMOUT_C IN 2", "FRDDR_C OUT 2",
++				"TDM_C Playback", "TDMOUT_C OUT",
++				"TDMIN_A IN 4", "TDM_B Loopback",
++				"TDMIN_B IN 4", "TDM_B Loopback",
++				"TDMIN_C IN 4", "TDM_B Loopback",
++				"TDMIN_LB IN 1", "TDM_B Loopback",
++				"TDMIN_A IN 5", "TDM_C Loopback",
++				"TDMIN_B IN 5", "TDM_C Loopback",
++				"TDMIN_C IN 5", "TDM_C Loopback",
++				"TDMIN_LB IN 2", "TDM_C Loopback",
++				"TODDR_A IN 0", "TDMIN_A OUT",
++				"TODDR_B IN 0", "TDMIN_A OUT",
++				"TODDR_C IN 0", "TDMIN_A OUT",
++				"TODDR_A IN 1", "TDMIN_B OUT",
++				"TODDR_B IN 1", "TDMIN_B OUT",
++				"TODDR_C IN 1", "TDMIN_B OUT",
++				"TODDR_A IN 2", "TDMIN_C OUT",
++				"TODDR_B IN 2", "TDMIN_C OUT",
++				"TODDR_C IN 2", "TDMIN_C OUT",
++				"TODDR_A IN 6", "TDMIN_LB OUT",
++				"TODDR_B IN 6", "TDMIN_LB OUT",
++				"TODDR_C IN 6", "TDMIN_LB OUT",
++				"U19 INL", "ACODEC LOLP",
++				"U19 INR", "ACODEC LORP",
++				"Lineout", "U19 OUTL",
++				"Lineout", "U19 OUTR";
+ 
+ 		assigned-clocks = <&clkc CLKID_MPLL2>,
+ 				  <&clkc CLKID_MPLL0>,
+@@ -236,8 +276,20 @@
+ 			sound-dai = <&frddr_c>;
+ 		};
+ 
+-		/* 8ch hdmi interface */
+ 		dai-link-3 {
++			sound-dai = <&toddr_a>;
++		};
++
++		dai-link-4 {
++			sound-dai = <&toddr_b>;
++		};
++
++		dai-link-5 {
++			sound-dai = <&toddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-6 {
+ 			sound-dai = <&tdmif_b>;
+ 			dai-format = "i2s";
+ 			dai-tdm-slot-tx-mask-0 = <1 1>;
+@@ -246,22 +298,56 @@
+ 			dai-tdm-slot-tx-mask-3 = <1 1>;
+ 			mclk-fs = <256>;
+ 
+-			codec {
++			codec-0 {
+ 				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
+ 			};
++
++			codec-1 {
++				sound-dai = <&toacodec TOACODEC_IN_B>;
++			};
++		};
++
++		/* i2s jack output interface */
++		dai-link-7 {
++			sound-dai = <&tdmif_c>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			mclk-fs = <256>;
++
++			codec-0 {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_C>;
++			};
++
++			codec-1 {
++				sound-dai = <&toacodec TOACODEC_IN_C>;
++			};
+ 		};
+ 
+ 		/* hdmi glue */
+-		dai-link-4 {
++		dai-link-8 {
+ 			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
+ 
+ 			codec {
+ 				sound-dai = <&hdmi_tx>;
+ 			};
+ 		};
++
++		/* acodec glue */
++		dai-link-9 {
++			sound-dai = <&toacodec TOACODEC_OUT>;
++
++			codec {
++				sound-dai = <&acodec>;
++			};
++		};
+ 	};
+ };
+ 
++&acodec {
++	AVDD-supply = <&vddao_1v8>;
++	status = "okay";
++};
++
+ &arb {
+ 	status = "okay";
+ };
+@@ -476,14 +562,54 @@
+ 	status = "okay";
+ };
+ 
++&tdmif_c {
++	status = "okay";
++};
++
++&tdmin_a {
++	status = "okay";
++};
++
++&tdmin_b {
++	status = "okay";
++};
++
++&tdmin_c {
++	status = "okay";
++};
++
++&tdmin_lb {
++	status = "okay";
++};
++
+ &tdmout_b {
+ 	status = "okay";
+ };
+ 
++&tdmout_c {
++	status = "okay";
++};
++
++&toacodec {
++	status = "okay";
++};
++
+ &tohdmitx {
+ 	status = "okay";
+ };
+ 
++&toddr_a {
++	status = "okay";
++};
++
++&toddr_b {
++	status = "okay";
++};
++
++&toddr_c {
++	status = "okay";
++};
++
+ &uart_AO {
+ 	status = "okay";
+ 	pinctrl-0 = <&uart_ao_a_pins>;
+diff --git a/arch/arm/dts/meson-khadas-vim3.dtsi b/arch/arm/dts/meson-khadas-vim3.dtsi
+index 1ef1e3672b96..94f75b446504 100644
+--- a/arch/arm/dts/meson-khadas-vim3.dtsi
++++ b/arch/arm/dts/meson-khadas-vim3.dtsi
+@@ -183,6 +183,23 @@
+ 	hdmi-phandle = <&hdmi_tx>;
+ };
+ 
++&cpu_thermal {
++	trips {
++		cpu_active: cpu-active {
++			temperature = <80000>; /* millicelsius */
++			hysteresis = <2000>; /* millicelsius */
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map {
++			trip = <&cpu_active>;
++			cooling-device = <&khadas_mcu THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
+ &ext_mdio {
+ 	external_phy: ethernet-phy@0 {
+ 		/* Realtek RTL8211F (0x001cc916) */
+@@ -222,6 +239,12 @@
+ 	pinctrl-0 = <&i2c_ao_sck_pins>, <&i2c_ao_sda_pins>;
+ 	pinctrl-names = "default";
+ 
++	khadas_mcu: system-controller@18 {
++		compatible = "khadas,mcu";
++		reg = <0x18>;
++		#cooling-cells = <2>;
++	};
++
+ 	gpio_expander: gpio-controller@20 {
+ 		compatible = "ti,tca6408";
+ 		reg = <0x20>;
+@@ -270,7 +293,6 @@
+ 
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
+-	sd-uhs-sdr50;
+ 	max-frequency = <100000000>;
+ 
+ 	non-removable;
+@@ -337,7 +359,7 @@
+ 	pinctrl-0 = <&nor_pins>;
+ 	pinctrl-names = "default";
+ 
+-	w25q32: spi-flash@0 {
++	w25q128: spi-flash@0 {
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+ 		compatible = "winbond,w25q128fw", "jedec,spi-nor";
+diff --git a/arch/arm/dts/meson-sm1-khadas-vim3l.dts b/arch/arm/dts/meson-sm1-khadas-vim3l.dts
+index dbbf29a0dbf6..0da56c051a0e 100644
+--- a/arch/arm/dts/meson-sm1-khadas-vim3l.dts
++++ b/arch/arm/dts/meson-sm1-khadas-vim3l.dts
+@@ -8,6 +8,7 @@
+ 
+ #include "meson-sm1.dtsi"
+ #include "meson-khadas-vim3.dtsi"
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
+ 
+ / {
+ 	compatible = "khadas,vim3l", "amlogic,sm1";
+@@ -31,6 +32,69 @@
+ 		regulator-boot-on;
+ 		regulator-always-on;
+ 	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		model = "SM1-KHADAS-VIM3L";
++		audio-aux-devs = <&tdmout_a>;
++		audio-routing = "TDMOUT_A IN 0", "FRDDR_A OUT 0",
++				"TDMOUT_A IN 1", "FRDDR_B OUT 0",
++				"TDMOUT_A IN 2", "FRDDR_C OUT 0",
++				"TDM_A Playback", "TDMOUT_A OUT";
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++		status = "okay";
++
++		dai-link-0 {
++			sound-dai = <&frddr_a>;
++		};
++
++		dai-link-1 {
++			sound-dai = <&frddr_b>;
++		};
++
++		dai-link-2 {
++			sound-dai = <&frddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-3 {
++			sound-dai = <&tdmif_a>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_A>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-4 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++};
++
++&arb {
++	status = "okay";
++};
++
++&clkc_audio {
++	status = "okay";
+ };
+ 
+ &cpu0 {
+@@ -61,6 +125,18 @@
+ 	clock-latency = <50000>;
+ };
+ 
++&frddr_a {
++	status = "okay";
++};
++
++&frddr_b {
++	status = "okay";
++};
++
++&frddr_c {
++	status = "okay";
++};
++
+ &pwm_AO_cd {
+ 	pinctrl-0 = <&pwm_ao_d_e_pins>;
+ 	pinctrl-names = "default";
+@@ -88,8 +164,24 @@
+ 	status = "okay";
+ };
+ 
++&sd_emmc_a {
++	sd-uhs-sdr50;
++};
++
+ &usb {
+ 	phys = <&usb2_phy0>, <&usb2_phy1>;
+ 	phy-names = "usb2-phy0", "usb2-phy1";
+ };
+  */
++
++&tdmif_a {
++	status = "okay";
++};
++
++&tdmout_a {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
+diff --git a/arch/arm/dts/meson-sm1-odroid-c4.dts b/arch/arm/dts/meson-sm1-odroid-c4.dts
+index 00d90b30f8b4..cf5a98f0e47c 100644
+--- a/arch/arm/dts/meson-sm1-odroid-c4.dts
++++ b/arch/arm/dts/meson-sm1-odroid-c4.dts
+@@ -8,6 +8,7 @@
+ #include "meson-sm1.dtsi"
+ #include <dt-bindings/gpio/meson-g12a-gpio.h>
+ #include <dt-bindings/leds/common.h>
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
+ 
+ / {
+ 	compatible = "hardkernel,odroid-c4", "amlogic,sm1";
+@@ -186,6 +187,69 @@
+ 			};
+ 		};
+ 	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		model = "SM1-ODROID-C4";
++		audio-aux-devs = <&tdmout_b>;
++		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
++				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
++				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
++				"TDM_B Playback", "TDMOUT_B OUT";
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++		status = "okay";
++
++		dai-link-0 {
++			sound-dai = <&frddr_a>;
++		};
++
++		dai-link-1 {
++			sound-dai = <&frddr_b>;
++		};
++
++		dai-link-2 {
++			sound-dai = <&frddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-3 {
++			sound-dai = <&tdmif_b>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-4 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++};
++
++&arb {
++	status = "okay";
++};
++
++&clkc_audio {
++	status = "okay";
+ };
+ 
+ &cpu0 {
+@@ -237,6 +301,18 @@
+ 	amlogic,tx-delay-ns = <2>;
+ };
+ 
++&frddr_a {
++	status = "okay";
++};
++
++&frddr_b {
++	status = "okay";
++};
++
++&frddr_c {
++	status = "okay";
++};
++
+ &gpio {
+ 	gpio-line-names =
+ 		/* GPIOZ */
+@@ -381,6 +457,18 @@
+ 	vqmmc-supply = <&flash_1v8>;
+ };
+ 
++&tdmif_b {
++	status = "okay";
++};
++
++&tdmout_b {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
++
+ &uart_AO {
+ 	status = "okay";
+ 	pinctrl-0 = <&uart_ao_a_pins>;
+diff --git a/include/dt-bindings/clock/g12a-clkc.h b/include/dt-bindings/clock/g12a-clkc.h
+index b0d65d73db96..40d49940d8a8 100644
+--- a/include/dt-bindings/clock/g12a-clkc.h
++++ b/include/dt-bindings/clock/g12a-clkc.h
+@@ -145,5 +145,7 @@
+ #define CLKID_CPU3_CLK				255
+ #define CLKID_SPICC0_SCLK			258
+ #define CLKID_SPICC1_SCLK			261
++#define CLKID_NNA_AXI_CLK			264
++#define CLKID_NNA_CORE_CLK			267
+ 
+ #endif /* __G12A_CLKC_H */
+diff --git a/include/dt-bindings/sound/meson-g12a-toacodec.h b/include/dt-bindings/sound/meson-g12a-toacodec.h
+new file mode 100644
+index 000000000000..69d7a75592a2
+--- /dev/null
++++ b/include/dt-bindings/sound/meson-g12a-toacodec.h
+@@ -0,0 +1,10 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef __DT_MESON_G12A_TOACODEC_H
++#define __DT_MESON_G12A_TOACODEC_H
++
++#define TOACODEC_IN_A	0
++#define TOACODEC_IN_B	1
++#define TOACODEC_IN_C	2
++#define TOACODEC_OUT	3
++
++#endif /* __DT_MESON_G12A_TOACODEC_H */
+-- 
+2.28.0
+

--- a/recipes-bsp/u-boot/u-boot-meson-gx/0002-board-amlogic-add-a-vim3-specific-board-support.patch
+++ b/recipes-bsp/u-boot/u-boot-meson-gx/0002-board-amlogic-add-a-vim3-specific-board-support.patch
@@ -1,0 +1,79 @@
+5aeecbcf8190 board: amlogic: add a vim3 specific board support
+ board/amlogic/vim3/MAINTAINERS |  9 +++++++++
+ board/amlogic/vim3/Makefile    |  6 ++++++
+ board/amlogic/vim3/vim3.c      | 20 ++++++++++++++++++++
+ board/amlogic/w400/MAINTAINERS |  4 ----
+ 4 files changed, 35 insertions(+), 4 deletions(-)
+ create mode 100644 board/amlogic/vim3/MAINTAINERS
+ create mode 100644 board/amlogic/vim3/Makefile
+ create mode 100644 board/amlogic/vim3/vim3.c
+
+diff --git a/board/amlogic/vim3/MAINTAINERS b/board/amlogic/vim3/MAINTAINERS
+new file mode 100644
+index 000000000000..92b426f66df9
+--- /dev/null
++++ b/board/amlogic/vim3/MAINTAINERS
+@@ -0,0 +1,9 @@
++VIM3
++M:	Neil Armstrong <narmstrong@baylibre.com>
++S:	Maintained
++L:	u-boot-amlogic@groups.io
++F:	board/amlogic/vim3/
++F:	configs/khadas-vim3_defconfig
++F:	configs/khadas-vim3l_defconfig
++F:	doc/board/amlogic/khadas-vim3.rst
++F:	doc/board/amlogic/khadas-vim3l.rst
+diff --git a/board/amlogic/vim3/Makefile b/board/amlogic/vim3/Makefile
+new file mode 100644
+index 000000000000..c51507730211
+--- /dev/null
++++ b/board/amlogic/vim3/Makefile
+@@ -0,0 +1,6 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# (C) Copyright 2020 BayLibre, SAS
++# Author: Neil Armstrong <narmstrong@baylibre.com>
++
++obj-y	:= vim3.o
+diff --git a/board/amlogic/vim3/vim3.c b/board/amlogic/vim3/vim3.c
+new file mode 100644
+index 000000000000..02d8cd0ce0a7
+--- /dev/null
++++ b/board/amlogic/vim3/vim3.c
+@@ -0,0 +1,20 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2020 BayLibre, SAS
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ */
++
++#include <common.h>
++#include <dm.h>
++#include <env_internal.h>
++#include <init.h>
++#include <net.h>
++#include <asm/io.h>
++#include <asm/arch/eth.h>
++
++int misc_init_r(void)
++{
++	meson_eth_init(PHY_INTERFACE_MODE_RGMII, 0);
++
++	return 0;
++}
+diff --git a/board/amlogic/w400/MAINTAINERS b/board/amlogic/w400/MAINTAINERS
+index a1b0ac8636e7..991590d9f259 100644
+--- a/board/amlogic/w400/MAINTAINERS
++++ b/board/amlogic/w400/MAINTAINERS
+@@ -3,8 +3,4 @@ M:	Neil Armstrong <narmstrong@baylibre.com>
+ S:	Maintained
+ L:	u-boot-amlogic@groups.io
+ F:	board/amlogic/w400/
+-F:	configs/khadas-vim3_defconfig
+-F:	configs/khadas-vim3l_defconfig
+ F:	doc/board/amlogic/w400.rst
+-F:	doc/board/amlogic/khadas-vim3.rst
+-F:	doc/board/amlogic/khadas-vim3l.rst
+-- 
+2.28.0
+

--- a/recipes-bsp/u-boot/u-boot-meson-gx/0003-configs-vim3-use-the-vim3-board-support.patch
+++ b/recipes-bsp/u-boot/u-boot-meson-gx/0003-configs-vim3-use-the-vim3-board-support.patch
@@ -1,0 +1,30 @@
+cb4a7feb54b5 configs: vim3: use the vim3 board support
+ configs/khadas-vim3_defconfig  | 2 +-
+ configs/khadas-vim3l_defconfig | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configs/khadas-vim3_defconfig b/configs/khadas-vim3_defconfig
+index a39e0f9c9f54..ee5990426d83 100644
+--- a/configs/khadas-vim3_defconfig
++++ b/configs/khadas-vim3_defconfig
+@@ -1,5 +1,5 @@
+ CONFIG_ARM=y
+-CONFIG_SYS_BOARD="w400"
++CONFIG_SYS_BOARD="vim3"
+ CONFIG_ARCH_MESON=y
+ CONFIG_SYS_TEXT_BASE=0x01000000
+ CONFIG_NR_DRAM_BANKS=1
+diff --git a/configs/khadas-vim3l_defconfig b/configs/khadas-vim3l_defconfig
+index 57cc383b9d28..5729d339e9a3 100644
+--- a/configs/khadas-vim3l_defconfig
++++ b/configs/khadas-vim3l_defconfig
+@@ -1,5 +1,5 @@
+ CONFIG_ARM=y
+-CONFIG_SYS_BOARD="w400"
++CONFIG_SYS_BOARD="vim3"
+ CONFIG_ARCH_MESON=y
+ CONFIG_SYS_TEXT_BASE=0x01000000
+ CONFIG_NR_DRAM_BANKS=1
+-- 
+2.28.0
+

--- a/recipes-bsp/u-boot/u-boot-meson-gx/0004-board-amlogic-vim3-add-support-for-dynamic-PCIe-enab.patch
+++ b/recipes-bsp/u-boot/u-boot-meson-gx/0004-board-amlogic-vim3-add-support-for-dynamic-PCIe-enab.patch
@@ -1,0 +1,346 @@
+adbff64af7b7 board: amlogic: vim3: add support for dynamic PCIe enable
+ board/amlogic/vim3/khadas-mcu.h    |  81 ++++++++++++++++++++
+ board/amlogic/vim3/vim3.c          | 117 +++++++++++++++++++++++++++++
+ configs/khadas-vim3_defconfig      |   3 +
+ configs/khadas-vim3l_defconfig     |   3 +
+ doc/board/amlogic/khadas-vim3.rst  |  27 +++++++
+ doc/board/amlogic/khadas-vim3l.rst |  27 +++++++
+ 6 files changed, 258 insertions(+)
+ create mode 100644 board/amlogic/vim3/khadas-mcu.h
+
+diff --git a/board/amlogic/vim3/khadas-mcu.h b/board/amlogic/vim3/khadas-mcu.h
+new file mode 100644
+index 000000000000..de3758cafe2b
+--- /dev/null
++++ b/board/amlogic/vim3/khadas-mcu.h
+@@ -0,0 +1,81 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Khadas System control Microcontroller Register map
++ *
++ * Copyright (C) 2020 BayLibre SAS
++ *
++ * Author(s): Neil Armstrong <narmstrong@baylibre.com>
++ */
++
++#ifndef MFD_KHADAS_MCU_H
++#define MFD_KHADAS_MCU_H
++
++#define KHADAS_MCU_PASSWD_VEN_0_REG		0x00 /* RO */
++#define KHADAS_MCU_PASSWD_VEN_1_REG		0x01 /* RO */
++#define KHADAS_MCU_PASSWD_VEN_2_REG		0x02 /* RO */
++#define KHADAS_MCU_PASSWD_VEN_3_REG		0x03 /* RO */
++#define KHADAS_MCU_PASSWD_VEN_4_REG		0x04 /* RO */
++#define KHADAS_MCU_PASSWD_VEN_5_REG		0x05 /* RO */
++#define KHADAS_MCU_MAC_0_REG			0x06 /* RO */
++#define KHADAS_MCU_MAC_1_REG			0x07 /* RO */
++#define KHADAS_MCU_MAC_2_REG			0x08 /* RO */
++#define KHADAS_MCU_MAC_3_REG			0x09 /* RO */
++#define KHADAS_MCU_MAC_4_REG			0x0a /* RO */
++#define KHADAS_MCU_MAC_5_REG			0x0b /* RO */
++#define KHADAS_MCU_USID_0_REG			0x0c /* RO */
++#define KHADAS_MCU_USID_1_REG			0x0d /* RO */
++#define KHADAS_MCU_USID_2_REG			0x0e /* RO */
++#define KHADAS_MCU_USID_3_REG			0x0f /* RO */
++#define KHADAS_MCU_USID_4_REG			0x10 /* RO */
++#define KHADAS_MCU_USID_5_REG			0x11 /* RO */
++#define KHADAS_MCU_VERSION_0_REG		0x12 /* RO */
++#define KHADAS_MCU_VERSION_1_REG		0x13 /* RO */
++#define KHADAS_MCU_DEVICE_NO_0_REG		0x14 /* RO */
++#define KHADAS_MCU_DEVICE_NO_1_REG		0x15 /* RO */
++#define KHADAS_MCU_FACTORY_TEST_REG		0x16 /* R */
++#define KHADAS_MCU_BOOT_MODE_REG		0x20 /* RW */
++#define KHADAS_MCU_BOOT_EN_WOL_REG		0x21 /* RW */
++#define KHADAS_MCU_BOOT_EN_RTC_REG		0x22 /* RW */
++#define KHADAS_MCU_BOOT_EN_EXP_REG		0x23 /* RW */
++#define KHADAS_MCU_BOOT_EN_IR_REG		0x24 /* RW */
++#define KHADAS_MCU_BOOT_EN_DCIN_REG		0x25 /* RW */
++#define KHADAS_MCU_BOOT_EN_KEY_REG		0x26 /* RW */
++#define KHADAS_MCU_KEY_MODE_REG			0x27 /* RW */
++#define KHADAS_MCU_LED_MODE_ON_REG		0x28 /* RW */
++#define KHADAS_MCU_LED_MODE_OFF_REG		0x29 /* RW */
++#define KHADAS_MCU_SHUTDOWN_NORMAL_REG		0x2c /* RW */
++#define KHADAS_MCU_MAC_SWITCH_REG		0x2d /* RW */
++#define KHADAS_MCU_MCU_SLEEP_MODE_REG		0x2e /* RW */
++#define KHADAS_MCU_IR_CODE1_0_REG		0x2f /* RW */
++#define KHADAS_MCU_IR_CODE1_1_REG		0x30 /* RW */
++#define KHADAS_MCU_IR_CODE1_2_REG		0x31 /* RW */
++#define KHADAS_MCU_IR_CODE1_3_REG		0x32 /* RW */
++#define KHADAS_MCU_USB_PCIE_SWITCH_REG		0x33 /* RW */
++#define KHADAS_MCU_IR_CODE2_0_REG		0x34 /* RW */
++#define KHADAS_MCU_IR_CODE2_1_REG		0x35 /* RW */
++#define KHADAS_MCU_IR_CODE2_2_REG		0x36 /* RW */
++#define KHADAS_MCU_IR_CODE2_3_REG		0x37 /* RW */
++#define KHADAS_MCU_PASSWD_USER_0_REG		0x40 /* RW */
++#define KHADAS_MCU_PASSWD_USER_1_REG		0x41 /* RW */
++#define KHADAS_MCU_PASSWD_USER_2_REG		0x42 /* RW */
++#define KHADAS_MCU_PASSWD_USER_3_REG		0x43 /* RW */
++#define KHADAS_MCU_PASSWD_USER_4_REG		0x44 /* RW */
++#define KHADAS_MCU_PASSWD_USER_5_REG		0x45 /* RW */
++#define KHADAS_MCU_USER_DATA_0_REG		0x46 /* RW 56 bytes */
++#define KHADAS_MCU_PWR_OFF_CMD_REG		0x80 /* WO */
++#define KHADAS_MCU_PASSWD_START_REG		0x81 /* WO */
++#define KHADAS_MCU_CHECK_VEN_PASSWD_REG		0x82 /* WO */
++#define KHADAS_MCU_CHECK_USER_PASSWD_REG	0x83 /* WO */
++#define KHADAS_MCU_SHUTDOWN_NORMAL_STATUS_REG	0x86 /* RO */
++#define KHADAS_MCU_WOL_INIT_START_REG		0x87 /* WO */
++#define KHADAS_MCU_CMD_FAN_STATUS_CTRL_REG	0x88 /* WO */
++
++enum {
++	KHADAS_BOARD_VIM1 = 0x1,
++	KHADAS_BOARD_VIM2,
++	KHADAS_BOARD_VIM3,
++	KHADAS_BOARD_EDGE = 0x11,
++	KHADAS_BOARD_EDGE_V,
++};
++
++#endif /* MFD_KHADAS_MCU_H */
+diff --git a/board/amlogic/vim3/vim3.c b/board/amlogic/vim3/vim3.c
+index 02d8cd0ce0a7..09ef39ff30ad 100644
+--- a/board/amlogic/vim3/vim3.c
++++ b/board/amlogic/vim3/vim3.c
+@@ -11,6 +11,123 @@
+ #include <net.h>
+ #include <asm/io.h>
+ #include <asm/arch/eth.h>
++#include <i2c.h>
++#include "khadas-mcu.h"
++
++/*
++ * The VIM3 on-board  MCU can mux the PCIe/USB3.0 shared differential
++ * lines using a FUSB340TMX USB 3.1 SuperSpeed Data Switch between
++ * an USB3.0 Type A connector and a M.2 Key M slot.
++ * The PHY driving these differential lines is shared between
++ * the USB3.0 controller and the PCIe Controller, thus only
++ * a single controller can use it.
++ */
++int meson_ft_board_setup(void *blob, struct bd_info *bd)
++{
++	struct udevice *bus, *dev;
++	int node, i2c_node, ret;
++	unsigned int i2c_addr;
++	u32 *val;
++
++	/* Find I2C device */
++	node = fdt_node_offset_by_compatible(gd->fdt_blob, -1, "khadas,mcu");
++	if (node < 0) {
++		printf("vim3: cannot find khadas,mcu node\n");
++		return 0;
++	}
++
++	/* Get addr */
++	val = (u32 *)fdt_getprop(gd->fdt_blob, node, "reg", NULL);
++	if (!val) {
++		printf("vim3: cannot find khadas,mcu node i2c addr\n");
++		return 0;
++	}
++	i2c_addr = fdt32_to_cpu(*val);
++
++	/* Get i2c device */
++	i2c_node = fdt_parent_offset(gd->fdt_blob, node);
++	if (node < 0) {
++		printf("vim3: cannot find khadas,mcu i2c node\n");
++		return 0;
++	}
++
++	ret = uclass_get_device_by_of_offset(UCLASS_I2C, i2c_node, &bus);
++	if (ret < 0) {
++		printf("vim3: cannot find i2c bus (%d)\n", ret);
++		return 0;
++	}
++
++	ret = i2c_get_chip(bus, i2c_addr, 1, &dev);
++	if (ret < 0) {
++		printf("vim3: cannot find i2c chip (%d)\n", ret);
++		return 0;
++	}
++
++	/* Read USB_PCIE_SWITCH_REG */
++	ret = dm_i2c_reg_read(dev, KHADAS_MCU_USB_PCIE_SWITCH_REG);
++	if (ret < 0) {
++		printf("vim3: failed to read i2c reg (%d)\n", ret);
++		return 0;
++	}
++	debug("MCU_USB_PCIE_SWITCH_REG: %d\n", ret);
++
++	/*
++	 * If in PCIe mode, alter DT
++	 * 0：Enable USB3.0，Disable PCIE, 1：Disable USB3.0, Enable PCIE
++	 */
++	if (ret > 0) {
++		static char data[32] __aligned(4);
++		const void *ptmp;
++		int len;
++
++		/* Find USB node */
++		node = fdt_node_offset_by_compatible(blob, -1, "amlogic,meson-g12a-usb-ctrl");
++		if (node < 0) {
++			printf("vim3: cannot find amlogic,meson-g12a-usb-ctrl node\n");
++			return 0;
++		}
++
++		/* Update PHY names (mandatory to disable USB3.0) */
++		len = strlcpy(data, "usb2-phy0", 32) + 1;
++		len += strlcpy(&data[len], "usb2-phy1", 32 - len) + 1;
++		ret = fdt_setprop(blob, node, "phy-names", data, len);
++		if (ret < 0) {
++			printf("vim3: failed to update usb phy names property (%d)\n", ret);
++			return 0;
++		}
++
++		/* Update PHY list, by keeping the 2 first entries (optional) */
++		ptmp = fdt_getprop(blob, node, "phys", &len);
++		if (ptmp) {
++			memcpy(data, ptmp, min_t(unsigned int, 2 * sizeof(u32), len));
++
++			ret = fdt_setprop(blob, node, "phys", data,
++					  min_t(unsigned int, 2 * sizeof(u32), len));
++			if (ret < 0)
++				printf("vim3: failed to update usb phys property (%d)\n", ret);
++		} else
++			printf("vim3: cannot find usb node phys property\n");
++
++		/* Find PCIe node */
++		node = fdt_node_offset_by_compatible(blob, -1, "amlogic,g12a-pcie");
++		if (node < 0) {
++			printf("vim3: cannot find amlogic,g12a-pcie node\n");
++			return 0;
++		}
++
++		/* Enable PCIe */
++		len = strlcpy(data, "okay", 32);
++		ret = fdt_setprop(blob, node, "status", data, len);
++		if (ret < 0) {
++			printf("vim3: failed to enable pcie node (%d)\n", ret);
++			return 0;
++		}
++
++		printf("vim3: successfully enabled PCIe\n");
++	}
++
++	return 0;
++}
+ 
+ int misc_init_r(void)
+ {
+diff --git a/configs/khadas-vim3_defconfig b/configs/khadas-vim3_defconfig
+index ee5990426d83..df2d5bda5b84 100644
+--- a/configs/khadas-vim3_defconfig
++++ b/configs/khadas-vim3_defconfig
+@@ -17,6 +17,7 @@ CONFIG_MISC_INIT_R=y
+ # CONFIG_CMD_BDI is not set
+ # CONFIG_CMD_IMI is not set
+ CONFIG_CMD_GPIO=y
++CONFIG_CMD_I2C=y
+ # CONFIG_CMD_LOADS is not set
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_SF_TEST=y
+@@ -28,6 +29,8 @@ CONFIG_CMD_REGULATOR=y
+ CONFIG_OF_CONTROL=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_DM_I2C=y
++CONFIG_SYS_I2C_MESON=y
+ CONFIG_DM_MMC=y
+ CONFIG_MMC_MESON_GX=y
+ CONFIG_MTD=y
+diff --git a/configs/khadas-vim3l_defconfig b/configs/khadas-vim3l_defconfig
+index 5729d339e9a3..39e74c3ccb37 100644
+--- a/configs/khadas-vim3l_defconfig
++++ b/configs/khadas-vim3l_defconfig
+@@ -17,6 +17,7 @@ CONFIG_MISC_INIT_R=y
+ # CONFIG_CMD_BDI is not set
+ # CONFIG_CMD_IMI is not set
+ CONFIG_CMD_GPIO=y
++CONFIG_CMD_I2C=y
+ # CONFIG_CMD_LOADS is not set
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_SF_TEST=y
+@@ -28,6 +29,8 @@ CONFIG_CMD_REGULATOR=y
+ CONFIG_OF_CONTROL=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_DM_I2C=y
++CONFIG_SYS_I2C_MESON=y
+ CONFIG_DM_MMC=y
+ CONFIG_MMC_MESON_GX=y
+ CONFIG_MTD=y
+diff --git a/doc/board/amlogic/khadas-vim3.rst b/doc/board/amlogic/khadas-vim3.rst
+index c1c03212d28c..d6a9642ad62c 100644
+--- a/doc/board/amlogic/khadas-vim3.rst
++++ b/doc/board/amlogic/khadas-vim3.rst
+@@ -18,6 +18,33 @@ Technology Co., Ltd. with the following specifications:
+ 
+ Schematics are available on the manufacturer website.
+ 
++PCIe Setup
++----------
++The VIM3 on-board  MCU can mux the PCIe/USB3.0 shared differential
++lines using a FUSB340TMX USB 3.1 SuperSpeed Data Switch between
++an USB3.0 Type A connector and a M.2 Key M slot.
++The PHY driving these differential lines is shared between
++the USB3.0 controller and the PCIe Controller, thus only
++a single controller can use it.
++
++To setup for PCIe, run the following commands from U-Boot:
++
++.. code-block:: none
++
++    i2c dev i2c@5000
++    i2c mw 0x18 0x33 1
++
++Then power-cycle the board.
++
++To set back to USB3.0, run the following commands from U-Boot:
++
++.. code-block:: none
++
++    i2c dev i2c@5000
++    i2c mw 0x18 0x33 0
++
++Then power-cycle the board.
++
+ U-Boot compilation
+ ------------------
+ 
+diff --git a/doc/board/amlogic/khadas-vim3l.rst b/doc/board/amlogic/khadas-vim3l.rst
+index b380c174560f..3c0a415a8750 100644
+--- a/doc/board/amlogic/khadas-vim3l.rst
++++ b/doc/board/amlogic/khadas-vim3l.rst
+@@ -18,6 +18,33 @@ Technology Co., Ltd. with the following specifications:
+ 
+ Schematics are available on the manufacturer website.
+ 
++PCIe Setup
++----------
++The VIM3 on-board  MCU can mux the PCIe/USB3.0 shared differential
++lines using a FUSB340TMX USB 3.1 SuperSpeed Data Switch between
++an USB3.0 Type A connector and a M.2 Key M slot.
++The PHY driving these differential lines is shared between
++the USB3.0 controller and the PCIe Controller, thus only
++a single controller can use it.
++
++To setup for PCIe, run the following commands from U-Boot:
++
++.. code-block:: none
++
++    i2c dev i2c@5000
++    i2c mw 0x18 0x33 1
++
++Then power-cycle the board.
++
++To set back to USB3.0, run the following commands from U-Boot:
++
++.. code-block:: none
++
++    i2c dev i2c@5000
++    i2c mw 0x18 0x33 0
++
++Then power-cycle the board.
++
+ U-Boot compilation
+ ------------------
+ 
+-- 
+2.28.0
+

--- a/recipes-bsp/u-boot/u-boot-meson-gx_2020.10.bb
+++ b/recipes-bsp/u-boot/u-boot-meson-gx_2020.10.bb
@@ -8,6 +8,10 @@ PROVIDES = "u-boot virtual/bootloader"
 SRC_URI_append = " \
 	file://acs_tool.py \
 	file://fit.cfg \
+	file://0001-ARM-dts-sync-amlogic-G12A-SM1-DT-from-Linux-5.9-rc1.patch \
+	file://0002-board-amlogic-add-a-vim3-specific-board-support.patch \
+	file://0003-configs-vim3-use-the-vim3-board-support.patch \
+	file://0004-board-amlogic-vim3-add-support-for-dynamic-PCIe-enab.patch \
 "
 
 deploy_axg () {


### PR DESCRIPTION
These patches were merged upstream after v2020.10 but are useful for
VIM3* platforms to support PCIe.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>