### PR TITLE
p200: switch to mainline u-boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Available S805 machines are :
  - amlogic-s805 (all S805 machines) : generic non-bootable .wic image to be customized
 
 Available S905 machines are :
- - amlogic-p200 : .wic image to be booted using vendor u-boot
+ - amlogic-p200 : complete wic sdcard image with mainline U-boot
+ - amlogic-p200-sdboot : .wic image to be booted using vendor u-boot
  - amlogic-p201 : .wic image to be booted using vendor u-boot
  - hardkernel-odroidc2 : complete .wic sdcard image with mainline U-boot
  - hardkernel-odroidc2-sdboot : .wic image to be booted using vendor u-boot

--- a/conf/machine/amlogic-p200-sdboot.conf
+++ b/conf/machine/amlogic-p200-sdboot.conf
@@ -1,0 +1,19 @@
+# Amlogic P200
+
+require conf/machine/include/amlogic-s905.inc
+require conf/machine/include/amlogic-p200-dtb.inc
+
+EXTRA_IMAGEDEPENDS += "u-boot s905-autoscript s905-autoscript-multiboot"
+
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-amlogic"
+PREFERRED_PROVIDER_u-boot = "u-boot-amlogic"
+PREFERRED_VERSION_u-boot-amlogic = "v2015.01%"
+
+UBOOT_MACHINE = "gxb_p200_v1_config"
+
+IMAGE_BOOT_FILES += " s905_autoscript aml_autoscript aml_autoscript.zip"
+
+# Generate an SDCard Image
+IMAGE_CLASSES += "image_types_meson"
+
+WKS_FILE = "sdimage-meson.wks"

--- a/conf/machine/amlogic-p200.conf
+++ b/conf/machine/amlogic-p200.conf
@@ -3,15 +3,22 @@
 require conf/machine/include/amlogic-s905.inc
 require conf/machine/include/amlogic-p200-dtb.inc
 
-EXTRA_IMAGEDEPENDS += "u-boot s905-autoscript s905-autoscript-multiboot"
+PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"
+PREFERRED_PROVIDER_u-boot = "u-boot-meson-gx"
+PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-amlogic"
-PREFERRED_PROVIDER_u-boot = "u-boot-amlogic"
-PREFERRED_VERSION_u-boot-amlogic = "v2015.01%"
+UBOOT_MACHINE = "p200_defconfig"
+UBOOT_EXTLINUX = "1"
+UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
+UBOOT_EXTLINUX_FDT = "../meson-gxbb-p200.dtb"
+UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 
-UBOOT_MACHINE = "gxb_p200_v1_config"
-
-IMAGE_BOOT_FILES += " s905_autoscript aml_autoscript aml_autoscript.zip"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
+       kernel-image \
+       kernel-devicetree \
+       u-boot-meson-gx \
+"
 
 # Generate an SDCard Image
 IMAGE_CLASSES += "image_types_meson"

--- a/recipes-bsp/u-boot/amlogic-fip-prebuilt.bb
+++ b/recipes-bsp/u-boot/amlogic-fip-prebuilt.bb
@@ -12,6 +12,7 @@ COMPATIBLE_MACHINE_khadas-vim3l = "khadas-vim3l"
 COMPATIBLE_MACHINE_amlogic-p212 = "amlogic-p212"
 COMPATIBLE_MACHINE_friendlyelec-nanopik2 = "friendlyelec-nanopik2"
 COMPATIBLE_MACHINE_amlogic-s400 = "amlogic-s400"
+COMPATIBLE_MACHINE_amlogic-p200 = "amlogic-p200"
 
 SUBDIR_libretech-cc = "lepotato"
 SUBDIR_libretech-ac = "lafrite"
@@ -22,6 +23,7 @@ SUBDIR_khadas-vim3l = "khadas-vim3l"
 SUBDIR_amlogic-p212 = "p212"
 SUBDIR_friendlyelec-nanopik2 = "nanopi-k2"
 SUBDIR_amlogic-s400 = "s400"
+SUBDIR_amlogic-p200 = "p200"
 
 DEPLOY_CMD_libretech-cc = "do_deploy_gxl"
 DEPLOY_CMD_libretech-ac = "do_deploy_gxl"
@@ -32,6 +34,7 @@ DEPLOY_CMD_khadas-vim3 = "do_deploy_g12b"
 DEPLOY_CMD_khadas-vim3l = "do_deploy_g12a"
 DEPLOY_CMD_friendlyelec-nanopik2 = "do_deploy_gxbb"
 DEPLOY_CMD_amlogic-s400="do_deploy_axg"
+DEPLOY_CMD_amlogic-p200="do_deploy_gxbb"
 
 LIC_FILES_CHKSUM = "file://lepotato/blx_fix.sh;md5=12ad2eef4a1dcc98f9eda15224b92836"
 


### PR DESCRIPTION
Switch the default MACHINE=amlogic-p200 to use mainline u-boot.
amlogic-p200-sdboot becomes the vendor u-boot version.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>