### PR TITLE
Allow UBOOT_EXTLINUX_ROOT override in local.conf

### DIFF
--- a/conf/machine/amlogic-p212.conf
+++ b/conf/machine/amlogic-p212.conf
@@ -15,7 +15,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 
 UBOOT_MACHINE = "p212_defconfig"
 UBOOT_EXTLINUX = "1"
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk0p1"
 UBOOT_EXTLINUX_FDT = "../meson-gxl-s905x-p212.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 

--- a/conf/machine/amlogic-s400.conf
+++ b/conf/machine/amlogic-s400.conf
@@ -14,7 +14,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 
 UBOOT_MACHINE = "s400_defconfig"
 UBOOT_EXTLINUX = "1"
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk0p1"
 UBOOT_EXTLINUX_FDT = "../meson-axg-s400.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 

--- a/conf/machine/friendlyelec-nanopik2.conf
+++ b/conf/machine/friendlyelec-nanopik2.conf
@@ -14,7 +14,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 
 UBOOT_MACHINE = "nanopi-k2_defconfig"
 UBOOT_EXTLINUX = "1"
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk0p1"
 UBOOT_EXTLINUX_FDT = "../meson-gxbb-nanopi-k2.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 

--- a/conf/machine/hardkernel-odroidc2.conf
+++ b/conf/machine/hardkernel-odroidc2.conf
@@ -15,7 +15,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 UBOOT_MACHINE = "odroid-c2_config"
 UBOOT_EXTLINUX = "1"
 # Boot on SDCard
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk1p1"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk1p1"
 UBOOT_EXTLINUX_FDT = "../meson-gxbb-odroidc2.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 

--- a/conf/machine/khadas-vim.conf
+++ b/conf/machine/khadas-vim.conf
@@ -14,7 +14,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 
 UBOOT_MACHINE = "khadas-vim_defconfig"
 UBOOT_EXTLINUX = "1"
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk0p1"
 UBOOT_EXTLINUX_FDT = "../meson-gxl-s905x-khadas-vim.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 

--- a/conf/machine/khadas-vim3.conf
+++ b/conf/machine/khadas-vim3.conf
@@ -22,7 +22,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 
 UBOOT_MACHINE = "khadas-vim3_defconfig"
 UBOOT_EXTLINUX = "1"
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk0p1"
 UBOOT_EXTLINUX_FDT = "../meson-g12b-a311d-khadas-vim3.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 

--- a/conf/machine/khadas-vim3l.conf
+++ b/conf/machine/khadas-vim3l.conf
@@ -14,7 +14,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 
 UBOOT_MACHINE = "khadas-vim3l_defconfig"
 UBOOT_EXTLINUX = "1"
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk0p1"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk0p1"
 UBOOT_EXTLINUX_FDT = "../meson-sm1-khadas-vim3l.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 

--- a/conf/machine/libretech-ac.conf
+++ b/conf/machine/libretech-ac.conf
@@ -15,7 +15,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 UBOOT_MACHINE = "libretech-ac_defconfig"
 UBOOT_EXTLINUX = "1"
 # Boot on SDCard
-UBOOT_EXTLINUX_ROOT = "root=/dev/sda1"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/sda1"
 UBOOT_EXTLINUX_FDT = "../meson-gxl-s805x-libretech-ac.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 

--- a/conf/machine/libretech-cc.conf
+++ b/conf/machine/libretech-cc.conf
@@ -15,7 +15,7 @@ PREFERRED_VERSION_u-boot-meson-gx = "2020.10%"
 UBOOT_MACHINE = "libretech-cc_defconfig"
 UBOOT_EXTLINUX = "1"
 # Boot on SDCard
-UBOOT_EXTLINUX_ROOT = "root=/dev/mmcblk1p1"
+UBOOT_EXTLINUX_ROOT ?= "root=/dev/mmcblk1p1"
 UBOOT_EXTLINUX_FDT = "../meson-gxl-s905x-libretech-cc.dtb"
 UBOOT_EXTLINUX_CONSOLE = "console=ttyAML0"
 


### PR DESCRIPTION
Use a soft assignment of UBOOT_EXTLINUX_ROOT so that you
can override it in your local.conf.

Fixes issue #107 

Signed-off-by: Matt Spencer <matthew@thespencers.me.uk>