### PR TITLE
Fix IMAGE_BOOT_FILES_append for some machines

### DIFF
--- a/conf/machine/hardkernel-odroidc4.conf
+++ b/conf/machine/hardkernel-odroidc4.conf
@@ -5,7 +5,7 @@ require conf/machine/include/hardkernel-odroidc4-dtb.inc
 
 KERNEL_IMAGETYPE = "Image"
 IMAGE_BOOT_FILES_remove = "uImage"
-IMAGE_BOOT_FILES_append = "Image"
+IMAGE_BOOT_FILES_append = " Image"
 
 PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"

--- a/conf/machine/hardkernel-odroidhc4.conf
+++ b/conf/machine/hardkernel-odroidhc4.conf
@@ -5,7 +5,7 @@ require conf/machine/include/hardkernel-odroidhc4-dtb.inc
 
 KERNEL_IMAGETYPE = "Image"
 IMAGE_BOOT_FILES_remove = "uImage"
-IMAGE_BOOT_FILES_append = "Image"
+IMAGE_BOOT_FILES_append = " Image"
 
 PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"

--- a/conf/machine/hardkernel-odroidn2.conf
+++ b/conf/machine/hardkernel-odroidn2.conf
@@ -5,7 +5,7 @@ require conf/machine/include/hardkernel-odroidn2-dtb.inc
 
 KERNEL_IMAGETYPE = "Image"
 IMAGE_BOOT_FILES_remove = "uImage"
-IMAGE_BOOT_FILES_append = "Image"
+IMAGE_BOOT_FILES_append = " Image"
 
 PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"

--- a/conf/machine/hardkernel-odroidn2plus.conf
+++ b/conf/machine/hardkernel-odroidn2plus.conf
@@ -5,7 +5,7 @@ require conf/machine/include/hardkernel-odroidn2plus-dtb.inc
 
 KERNEL_IMAGETYPE = "Image"
 IMAGE_BOOT_FILES_remove = "uImage"
-IMAGE_BOOT_FILES_append = "Image"
+IMAGE_BOOT_FILES_append = " Image"
 
 PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"

--- a/conf/machine/khadas-vim3l.conf
+++ b/conf/machine/khadas-vim3l.conf
@@ -5,7 +5,8 @@ require conf/machine/include/khadas-vim3l-dtb.inc
 
 KERNEL_IMAGETYPE = "Image"
 IMAGE_BOOT_FILES_remove = "uImage"
-IMAGE_BOOT_FILES_append = "Image"
+IMAGE_BOOT_FILES_append = " Image"
+
 
 PREFERRED_PROVIDER_amlogic-fip = "amlogic-fip-prebuilt"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-meson-gx"


### PR DESCRIPTION
It needs to have space before assignment in order to work
with more than one file.