### PR TITLE
Add a basic kas config

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,26 @@ You will be able to dd the image onto the raw SDcard like :
 ```
 sudo dd if=tmp/deploy/images/libretech-cc/core-image-sato-libretech-cc.wic of=/dev/mmcblk0
 ```
+
+## Build with kas
+
+The `kas` tool is installed via Python pip. The recommended way is to use an virtual environment for this.
+
+```
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip3 install wheel kas
+```
+
+To start a build we just need to run the command `kas build <configuration>.yml`
+
+```
+$ source venv/bin/activate
+$ DL_DIR=/data/downloads SSTATE_DIR=/data/sstate-cache kas build kas/kas-poky-meson.yml
+```
+
+The environment variable `DL_DIR` will allow to use a common place for the downloads across different projects. The same applies to the `SSTATE_DIR` variable.
+
+To build for a specific machine use the environment variable `KAS_MACHINE`.
+
+Please check the [kas](https://kas.readthedocs.io/en/latest/) manual for more details.

--- a/kas/kas-poky-meson.yml
+++ b/kas/kas-poky-meson.yml
@@ -1,0 +1,54 @@
+header:
+  version: 8
+
+machine: amediatech-x96-max
+distro: poky
+target:
+  - amlogic-image-headless-sd
+
+repos:
+  meta-meson:
+
+  poky:
+    url: https://git.yoctoproject.org/git/poky
+    path: layers/poky
+    refspec: kirkstone
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: http://git.openembedded.org/meta-openembedded
+    path: layers/meta-openembedded
+    refspec: kirkstone
+    layers:
+      meta-oe:
+      meta-python:
+      meta-networking:
+      meta-perl:
+
+bblayers_conf_header:
+  standard: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+    BBPATH = "${TOPDIR}"
+    BBFILES ?= ""
+local_conf_header:
+  reduce_diskspace: |
+    INHERIT += "rm_work"
+  standard: |
+    CONF_VERSION = "2"
+    PACKAGE_CLASSES = "package_ipk"
+    USER_CLASSES = "buildstats"
+  debug-tweaks: |
+    EXTRA_IMAGE_FEATURES = "debug-tweaks"
+  diskmon: |
+    BB_DISKMON_DIRS = "\
+        STOPTASKS,${TMPDIR},1G,100K \
+        STOPTASKS,${DL_DIR},1G,100K \
+        STOPTASKS,${SSTATE_DIR},1G,100K \
+        STOPTASKS,/tmp,100M,100K \
+        ABORT,${TMPDIR},100M,1K \
+        ABORT,${DL_DIR},100M,1K \
+        ABORT,${SSTATE_DIR},100M,1K \
+        ABORT,/tmp,10M,1K"


### PR DESCRIPTION
kas is a set-up tool for bitbake projekts. It simplifies the local.conf
and bblayer file handling. It also provides the possibility to include
configurations from other layers.

Signed-off-by: Christian Ege <ch@ege.io>