### PR TITLE
Support radxa-zero using mainline u-boot (kirkstone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Available S905X2 machines are :
  - amediatech-x96-max: .wic image to be booted using vendor u-boot
  - seirobotics-sei510: complete bootable .wic sdcard image with mainline U-boot
 
+Available S905Y2 machines are :
+ - radxa-zero: complete bootable .wic sdcard image with mainline U-boot
+
 Available S922X machines are :
  - hardkernel-odroidn2: complete bootable .wic sdcard image with mainline U-boot
  - hardkernel-odroidn2-sdboot: .wic image to be booted using vendor u-boot

--- a/conf/machine/amlogic-s905.conf
+++ b/conf/machine/amlogic-s905.conf
@@ -13,5 +13,6 @@ require conf/machine/include/nexbox-a95x-s905-dtb.inc
 require conf/machine/include/wetek-hub-dtb.inc
 require conf/machine/include/wetek-play2-dtb.inc
 require conf/machine/include/friendlyelec-nanopik2-dtb.inc
+require conf/machine/include/radxa-zero-dtb.inc
 
 KERNEL_IMAGETYPE ?= "Image"

--- a/conf/machine/amlogic-s9xxx.conf
+++ b/conf/machine/amlogic-s9xxx.conf
@@ -40,6 +40,7 @@ require conf/machine/include/seirobotics-sei610-dtb.inc
 require conf/machine/include/hardkernel-odroidn2plus-dtb.inc
 require conf/machine/include/hardkernel-odroidc4-dtb.inc
 require conf/machine/include/hardkernel-odroidhc4-dtb.inc
+require conf/machine/include/radxa-zero-dtb.inc
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
 KERNEL_IMAGETYPE = "uImage"

--- a/conf/machine/include/radxa-zero-dtb.inc
+++ b/conf/machine/include/radxa-zero-dtb.inc
@@ -1,0 +1,4 @@
+# Radxa Zero dtb
+
+KERNEL_DEVICETREE += "amlogic/meson-g12a-radxa-zero.dtb"
+IMAGE_BOOT_FILES += "meson-g12a-radxa-zero.dtb"

--- a/conf/machine/radxa-zero.conf
+++ b/conf/machine/radxa-zero.conf
@@ -1,0 +1,12 @@
+#@TYPE: Machine
+#@NAME: Radxa-Zero machine
+#@DESCRIPTION: Machine configuration
+
+require conf/machine/include/amlogic-s905y2.inc
+require conf/machine/include/radxa-zero-dtb.inc
+require conf/machine/include/amlogic-modern-boot.inc
+
+MACHINE_FEATURES:append = " alsa ext2 screen usbgadget usbhost vfat"
+
+
+UBOOT_MACHINE = "radxa-zero_config"

--- a/recipes-bsp/trusted-firmware-a/amlogic-boot-fip.bb
+++ b/recipes-bsp/trusted-firmware-a/amlogic-boot-fip.bb
@@ -28,6 +28,7 @@ COMPATIBLE_MACHINE:hardkernel-odroidn2 = "hardkernel-odroidn2"
 COMPATIBLE_MACHINE:hardkernel-odroidn2plus = "hardkernel-odroidn2plus"
 COMPATIBLE_MACHINE:seirobotics-sei510 = "seirobotics-sei510"
 COMPATIBLE_MACHINE:seirobotics-sei610 = "seirobotics-sei610"
+COMPATIBLE_MACHINE:radxa-zero = "radxa-zero"
 
 MODEL:libretech-cc = "lepotato"
 MODEL:libretech-ac = "lafrite"
@@ -47,6 +48,7 @@ MODEL:hardkernel-odroidn2 = "odroid-n2"
 MODEL:hardkernel-odroidn2plus = "odroid-n2-plus"
 MODEL:seirobotics-sei510 = "sei510"
 MODEL:seirobotics-sei610 = "sei610"
+MODEL:radxa-zero = "radxa-zero"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2dbd68496cc5ed3e68e855100cb86363"
 

--- a/recipes-kernel/linux/linux-yocto/0002-FROMLIST-arm64-dts-amlogic-add-support-for-radxa-zero.patch
+++ b/recipes-kernel/linux/linux-yocto/0002-FROMLIST-arm64-dts-amlogic-add-support-for-radxa-zero.patch
@@ -1,0 +1,452 @@
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Thu,  9 Sep 2021 10:21:54 +0000
+Subject: [PATCH v3 2/2] arm64: dts: amlogic: add support for Radxa Zero
+
+Radxa Zero is a small form factor SBC based on the Amlogic S905Y2
+chipset that ships in a number of RAM/eMMC configurations:
+
+Boards with 512MB/1GB LPDDR4 RAM have no eMMC storage and BCM43436
+wireless (2.4GHz b/g/n) while 2GB/4GB boards have 8/16/32/64/128GB
+eMMC storage and BCM4345 wireless (2.4/5GHz a/b/g/n/ac).
+
+- Amlogic S905Y2 quad-core Cortex-A53
+- Mali G31-MP2 GPU
+- HDMI 2.1 output (micro)
+- 1x USB 2.0 port - Type C (OTG)
+- 1x USB 3.0 port - Type C (Host)
+- 1x micro SD Card slot
+- 40 Pin GPIO header
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ arch/arm64/boot/dts/amlogic/Makefile          |   1 +
+ .../dts/amlogic/meson-g12a-radxa-zero.dts     | 405 ++++++++++++++++++
+ 2 files changed, 406 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+
+diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
+index faa0a79a34f5..be308361e2f1 100644
+--- a/arch/arm64/boot/dts/amlogic/Makefile
++++ b/arch/arm64/boot/dts/amlogic/Makefile
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+ dtb-$(CONFIG_ARCH_MESON) += meson-axg-s400.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-g12a-radxa-zero.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12a-sei510.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12a-u200.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12a-x96-max.dtb
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+new file mode 100644
+index 000000000000..e3bb6df42ff3
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -0,0 +1,405 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2018 BayLibre SAS. All rights reserved.
++ */
++
++/dts-v1/;
++
++#include "meson-g12a.dtsi"
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
++
++/ {
++	compatible = "radxa,zero", "amlogic,g12a";
++	model = "Radxa Zero";
++
++	aliases {
++		serial0 = &uart_AO;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x40000000>;
++	};
++
++	cvbs-connector {
++		status = "disabled";
++		compatible = "composite-video-connector";
++
++		port {
++			cvbs_connector_in: endpoint {
++				remote-endpoint = <&cvbs_vdac_out>;
++			};
++		};
++	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&gpio GPIOX_6 GPIO_ACTIVE_LOW>;
++		clocks = <&wifi32k>;
++		clock-names = "ext_clock";
++	};
++
++	ao_5v: regulator-ao_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "AO_5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	vcc_1v8: regulator-vcc_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	vcc_3v3: regulator-vcc_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	hdmi_pw: regulator-hdmi_pw {
++		compatible = "regulator-fixed";
++		regulator-name = "HDMI_PW";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&ao_5v>;
++		regulator-always-on;
++	};
++
++	vddao_1v8: regulator-vddao_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&ao_5v>;
++		regulator-always-on;
++	};
++
++	vddcpu: regulator-vddcpu {
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU";
++		regulator-min-microvolt = <721000>;
++		regulator-max-microvolt = <1022000>;
++
++		vin-supply = <&ao_5v>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		model = "RADXA-ZERO";
++		audio-aux-devs = <&tdmout_b>;
++		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
++				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
++				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
++				"TDM_B Playback", "TDMOUT_B OUT";
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++		status = "okay";
++
++		dai-link-0 {
++			sound-dai = <&frddr_a>;
++		};
++
++		dai-link-1 {
++			sound-dai = <&frddr_b>;
++		};
++
++		dai-link-2 {
++			sound-dai = <&frddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-3 {
++			sound-dai = <&tdmif_b>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
++			};
++		};
++
++		dai-link-4 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++
++	wifi32k: wifi32k {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		clock-frequency = <32768>;
++		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
++	};
++};
++
++&arb {
++	status = "okay";
++};
++
++&cec_AO {
++	pinctrl-0 = <&cec_ao_a_h_pins>;
++	pinctrl-names = "default";
++	status = "disabled";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cecb_AO {
++	pinctrl-0 = <&cec_ao_b_h_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&clkc_audio {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu2 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu3 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cvbs_vdac_port {
++	cvbs_vdac_out: endpoint {
++		remote-endpoint = <&cvbs_connector_in>;
++	};
++};
++
++&frddr_a {
++	status = "okay";
++};
++
++&frddr_b {
++	status = "okay";
++};
++
++&frddr_c {
++	status = "okay";
++};
++
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&hdmi_pw>;
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++&ir {
++	status = "disabled";
++	pinctrl-0 = <&remote_input_ao_pins>;
++	pinctrl-names = "default";
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin1";
++	status = "okay";
++};
++
++&pwm_ef {
++	status = "okay";
++	pinctrl-0 = <&pwm_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin0";
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vddao_1v8>;
++};
++
++/* SDIO */
++&sd_emmc_a {
++	status = "okay";
++	pinctrl-0 = <&sdio_pins>;
++	pinctrl-1 = <&sdio_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	sd-uhs-sdr50;
++	max-frequency = <100000000>;
++
++	non-removable;
++	disable-wp;
++
++	/* WiFi firmware requires power to be kept while in suspend */
++	keep-power-in-suspend;
++
++	mmc-pwrseq = <&sdio_pwrseq>;
++
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
++
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++	};
++};
++
++/* SD card */
++&sd_emmc_b {
++	status = "okay";
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <100000000>;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_3v3>;
++};
++
++/* eMMC */
++&sd_emmc_c {
++	status = "okay";
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&vcc_1v8>;
++};
++
++&tdmif_b {
++	status = "okay";
++};
++
++&tdmout_b {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
++
++&uart_A {
++	status = "okay";
++	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
++	pinctrl-names = "default";
++	uart-has-rtscts;
++
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		shutdown-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>;
++		max-speed = <2000000>;
++		clocks = <&wifi32k>;
++		clock-names = "lpo";
++	};
++};
++
++&uart_AO {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++};
++
++&usb {
++	status = "okay";
++	dr_mode = "host";
++};
+-- 
+2.17.1
+
+  

--- a/recipes-kernel/linux/linux-yocto_5.15.bbappend
+++ b/recipes-kernel/linux/linux-yocto_5.15.bbappend
@@ -1,3 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-yocto:"
 
 SRC_URI:append:meson-gx = " file://0001-drm-bridge-display-connector-implement-bus-fmts-call.patch;minrev=v5.16.62%;maxrev=v5.16.67"
+
+SRC_URI:append:meson-g12a = " file://0002-FROMLIST-arm64-dts-amlogic-add-support-for-radxa-zero.patch"


### PR DESCRIPTION
~~Haven't tested this just yet, but will shortly, submitting PR in the meantime to track here.~~

Addresses https://github.com/superna9999/meta-meson/issues/146 on kirkstone branch

Also brings the radxa-zero device tree patch in from lkml for kernels version 5.15.x
https://lkml.org/lkml/2021/9/9/250