### PR TITLE
wip: cleanup of linux-firmware

### DIFF
--- a/conf/machine/include/amlogic-meson.inc
+++ b/conf/machine/include/amlogic-meson.inc
@@ -14,18 +14,37 @@ XSERVER ?= "\
            xf86-video-modesetting \
 "
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
-       ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4329", "",d)} \
-       ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4330", "",d)} \
-       ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4335", "",d)} \
-       ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43362", "",d)} \
-       ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43430", "",d)} \
-       ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43430a0", "",d)} \
-       ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43455", "",d)} \
-       ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4354", "",d)} \
-       ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4356", "",d)} \
-       ${@bb.utils.contains("MACHINE_FEATURES", "screen", "linux-firmware-amlogic-vdec", "",d)} \
-"
+# TODO - the changes in linux-firmware_%.bbappend to new override syntax causes build failures when
+# installing either linux-firmware-bcm43430 or linux-firware-bcm43430a0:
+# - nothing provides linux-firmware-bcm43430a0 needed by packagegroup-core-boot-1.0-r17.radxa_zero
+#
+# Bascally including either of these in MACHINE_ESSENTIAL_EXTRA_RDEPENDS causes the above error
+# MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43430", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43430a0", "",d)} \
+# "
+# For now I'm taking an aggressive approach and not installing anything other than what I need, selfishly.
+#
+# TODO - figure out where these belong, probably in the machine conf _or_ using the :<machine> override syntax
+# as surely not all amlogic based systems need _all_ firmwares installed
+# MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4329", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4330", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4335", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43362", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43430", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43430a0", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43455", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4354", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm4356", "",d)} \
+#        ${@bb.utils.contains("MACHINE_FEATURES", "screen", "linux-firmware-amlogic-vdec", "",d)} \
+# "
+
+# An example using :<machine> override
+# MACHINE_ESSENTIAL_EXTRA_RDEPENDS:radxa-zero += " \
+#         ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43455", "",d)} \
+#         ${@bb.utils.contains("MACHINE_FEATURES", "wifi", "linux-firmware-bcm43456", "",d)} \
+# "
 
 IMAGE_FSTYPES += "tar.bz2 wic"
 do_image_wic[depends] += "mtools-native:do_populate_sysroot dosfstools-native:do_populate_sysroot"

--- a/conf/machine/radxa-zero.conf
+++ b/conf/machine/radxa-zero.conf
@@ -8,5 +8,15 @@ require conf/machine/include/amlogic-modern-boot.inc
 
 MACHINE_FEATURES:append = " alsa ext2 screen usbgadget usbhost vfat"
 
-
 UBOOT_MACHINE = "radxa-zero_config"
+
+# If this is populated in amlogic-meson.inc, it doesn't need
+# to be here as well.  This is just another method of specifying the correct
+# firmware for a given machine.  This seems to align more similarly with other repos vs.
+# doing this in amlogic-meson.inc
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
+       linux-firmware-bcm43455 \
+       linux-firmware-bcm43456 \
+       linux-firmware-bcm4345c0-hcd \
+       linux-firmware-bcm4345c5-hcd \
+"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -5,55 +5,70 @@ SRC_URI += " \
 	file://brcmfmac4354-sdio.txt \
 "
 
-SRCREV_brcmfmac-sdio-firmware = "3ddc301c272f081aa5513c1934f6d530bf80de4a"
+# This package is not in upstream linux-firmware repo, so add it here
+PACKAGES =+ " \
+       ${PN}-bcm43456 \
+       ${PN}-bcm4345c0-hcd \
+       ${PN}-bcm4345c5-hcd \
+"
+# Update sha to point to version that has firmware for Radxa-Zero
+SRCREV_brcmfmac-sdio-firmware = "3d63ae8b429103a6ef684f7237e048763318a2ba"
 
 do_install:append() {
-	for f in ${WORKDIR}/brcmfmac_sdio-firmware/*.txt ${WORKDIR}/brcmfmac_sdio-firmware/*.bin; do
+	for f in ${WORKDIR}/brcmfmac_sdio-firmware/*.txt ${WORKDIR}/brcmfmac_sdio-firmware/*.bin ${WORKDIR}/brcmfmac_sdio-firmware/*.hcd; do
 	        install -m 0644 $f ${D}${nonarch_base_libdir}/firmware/brcm
 	done
 	install -m 0644 ${WORKDIR}/brcmfmac4354-sdio.txt ${D}${nonarch_base_libdir}/firmware/brcm
 }
 
-FILES_${PN}-bcm4329 += " \
+FILES:${PN}-bcm4329 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac4329* \
 "
 
-FILES_${PN}-bcm4330 += " \
+FILES:${PN}-bcm4330 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac4330* \
 "
 
-FILES_${PN}-bcm4335 += " \
+FILES:${PN}-bcm4335 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac4335* \
 "
 
-FILES_${PN}-bcm43362 += " \
+FILES:${PN}-bcm43362 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac43362* \
 "
 
-FILES_${PN}-bcm43430 += " \
+FILES:${PN}-bcm43430 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac43430* \
 "
 
-FILES_${PN}-bcm43430a0 += " \
+FILES:${PN}-bcm43430a0 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac43430a0* \
 "
 
-FILES_${PN}-bcm43455 += " \
+FILES:${PN}-bcm43455 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac43455* \
 "
 
-FILES_${PN}-bcm43456 += " \
+FILES:${PN}-bcm4345c0-hcd += " \
+	${nonarch_base_libdir}/firmware/brcm/BCM4345C0.hcd \
+"
+
+FILES:${PN}-bcm43456 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac43456* \
 "
 
-FILES_${PN}-bcm4354 += " \
+FILES:${PN}-bcm4345c5-hcd += " \
+	${nonarch_base_libdir}/firmware/brcm/BCM4345C5.hcd \
+"
+
+FILES:${PN}-bcm4354 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac4354* \
 "
 
-FILES_${PN}-bcm4356 += " \
+FILES:${PN}-bcm4356 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac4356* \
 "
 
-FILES_${PN}-bcm4359 += " \
+FILES:${PN}-bcm4359 += " \
 	${nonarch_base_libdir}/firmware/brcm/brcmfmac4359* \
 "


### PR DESCRIPTION
Hi @superna9999  - this PR is just a start, mostly to be used as a discussion point on how to move forward 'cleaning' up the linux-firmware section of this repository.

It should be noted that because other than the `amlogic-image-bootstrap` image, the changes in this PR are sort of masked because the other image recipes explicitly include the `linux-firmware` package, which basically installs all Linux firmware(s) into the image.

I have verified the changes I've made here on my radxa-zero, using a custom image which enables wifi/bt for the radxa zero and _only_ installs the required firmware for the given hardware.

<h3>Known Issues</h3>

Currently this code only builds completely for the radxa-zero hardware (if you uncomment the `MACHINE_ESSENTIAL_EXTRA_RDEPENDS` in `amlogic-meson.inc`) .  I have locally one flavor of the radxa-zero hardware that requires the `linux-firmware-bcm43455` while a developer working with me in China has a radxa-zero that requires linux-firmware-bcm43456 (AP6256 WiFi Module).  These changes have been confirmed to work on both those boards.  I do not have another amlogic based devices to test on.

<h3>TODO</h3>

- [ ] Figure out what firmware(s) belong on which hardware (both wifi and bluetooth)
- [ ] Determine if it's more idoimatic to include, by way of machine overrides, the firmware in `amlogic-meson.inc` or push the firmware inclusion into the `<machine_name>.conf` file
- [ ] Figure out why a `nothing provides linux-firmware-bcmxxx` appears for some builds (as noted in the comments of `amlogic-meson.inc`