### PR TITLE
amlogic-meson: Generate wic bmap file

### DIFF
--- a/conf/machine/include/amlogic-meson.inc
+++ b/conf/machine/include/amlogic-meson.inc
@@ -27,7 +27,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
        ${@bb.utils.contains("MACHINE_FEATURES", "screen", "linux-firmware-amlogic-vdec", "",d)} \
 "
 
-IMAGE_FSTYPES += "tar.bz2 wic"
+IMAGE_FSTYPES += "tar.bz2 wic wic.bmap"
 do_image_wic[depends] += "mtools-native:do_populate_sysroot dosfstools-native:do_populate_sysroot"
 
 WKS_FILE ?= "sdimage-bootpart-meson.wks"


### PR DESCRIPTION
In addition to the wic image, also generate the wic.bmap file which allows bmaptool to efficiently copy the image.