### PR TITLE
classes/image_types_meson: Fix image creation

### DIFF
--- a/classes/image_types_meson.bbclass
+++ b/classes/image_types_meson.bbclass
@@ -6,12 +6,12 @@ WIC_COMMAND = "wic_command_meson_gx"
 WIC_COMMAND:amlogic-s400 = "wic_command_s400"
 
 wic_command_meson_gx () {
-	dd if=${DEPLOY_DIR_IMAGE}/u-boot.bin.sd.bin of=$out${IMAGE_NAME_SUFFIX}.wic conv=notrunc bs=1 count=440
-	dd if=${DEPLOY_DIR_IMAGE}/u-boot.bin.sd.bin of=$out${IMAGE_NAME_SUFFIX}.wic conv=notrunc bs=512 skip=1 seek=1
+	dd if=${DEPLOY_DIR_IMAGE}/u-boot.bin.sd.bin of=$out.wic conv=notrunc bs=1 count=440
+	dd if=${DEPLOY_DIR_IMAGE}/u-boot.bin.sd.bin of=$out.wic conv=notrunc bs=512 skip=1 seek=1
 }
 
 wic_command_s400 () {
-	dd if=${DEPLOY_DIR_IMAGE}/u-boot.bin.mmc.bin of=$out${IMAGE_NAME_SUFFIX}.wic conv=notrunc bs=512 seek=1
+	dd if=${DEPLOY_DIR_IMAGE}/u-boot.bin.mmc.bin of=$out.wic conv=notrunc bs=512 seek=1
 }
 
 IMAGE_CMD:wic:append () {


### PR DESCRIPTION
$IMAGE_NAME_SUFFIX no longer needs to be separately added to the image name, so remove it otherwise the images are not created correctly and will not boot.